### PR TITLE
Allow connection to be passed to constructor

### DIFF
--- a/Npgmq.Example/Program.cs
+++ b/Npgmq.Example/Program.cs
@@ -1,29 +1,61 @@
 ﻿using System.Reflection;
 using Microsoft.Extensions.Configuration;
 using Npgmq;
+using Npgsql;
 
 var configuration = new ConfigurationBuilder()
     .AddEnvironmentVariables()
     .AddUserSecrets(Assembly.GetExecutingAssembly())
     .Build();
 
-var npgmq = new NpgmqClient(configuration.GetConnectionString("ExampleDB")!);
+var connectionString = configuration.GetConnectionString("ExampleDB")!;
 
-await npgmq.InitAsync();
-await npgmq.CreateQueueAsync("example_queue");
-
-var msgId = await npgmq.SendAsync("example_queue", new MyMessageType
+// Test Npgmq with connection string
 {
-    Foo = "Test",
-    Bar = 123
-});
-Console.WriteLine($"Sent message with id {msgId}");
+    var npgmq = new NpgmqClient(connectionString);
 
-var msg = await npgmq.ReadAsync<MyMessageType>("example_queue");
-if (msg != null)
+    await npgmq.InitAsync();
+    await npgmq.CreateQueueAsync("example_queue");
+
+    var msgId = await npgmq.SendAsync("example_queue", new MyMessageType
+    {
+        Foo = "Connection string test",
+        Bar = 1
+    });
+    Console.WriteLine($"Sent message with id {msgId}");
+
+    var msg = await npgmq.ReadAsync<MyMessageType>("example_queue");
+    if (msg != null)
+    {
+        Console.WriteLine($"Read message with id {msg.MsgId}: Foo = {msg.Message?.Foo}, Bar = {msg.Message?.Bar}");
+        await npgmq.ArchiveAsync("example_queue", msg.MsgId);
+    }
+}
+
+// Test Npgmq with connection object and a transaction
 {
-    Console.WriteLine($"Read message with id {msg.MsgId}: Foo = {msg.Message?.Foo}, Bar = {msg.Message?.Bar}");
-    await npgmq.ArchiveAsync("example_queue", msg.MsgId);
+    await using var connection = new NpgsqlConnection(connectionString);
+    await connection.OpenAsync();
+    var npgmq = new NpgmqClient(connection);
+
+    await using (var tx = connection.BeginTransaction())
+    {
+        var msgId = await npgmq.SendAsync("example_queue", new MyMessageType
+        {
+            Foo = "Connection object test",
+            Bar = 2
+        });
+        Console.WriteLine($"Sent message with id {msgId}");
+
+        await tx.CommitAsync();
+    }
+
+    var msg = await npgmq.ReadAsync<MyMessageType>("example_queue");
+    if (msg != null)
+    {
+        Console.WriteLine($"Read message with id {msg.MsgId}: Foo = {msg.Message?.Foo}, Bar = {msg.Message?.Bar}");
+        await npgmq.ArchiveAsync("example_queue", msg.MsgId);
+    }
 }
 
 internal class MyMessageType

--- a/Npgmq.sln
+++ b/Npgmq.sln
@@ -8,6 +8,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		LICENSE = LICENSE
 		README.md = README.md
+		global.json = global.json
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{8C37002D-05C6-4B1F-B4FC-C2F45C5E5328}"

--- a/Npgmq/NpgmqCommand.cs
+++ b/Npgmq/NpgmqCommand.cs
@@ -1,0 +1,21 @@
+using System.Data;
+using Npgsql;
+
+namespace Npgmq;
+
+internal class NpgmqCommand(string commandText, NpgsqlConnection connection, bool disposeConnection)
+    : NpgsqlCommand(commandText, connection)
+{
+    public override async ValueTask DisposeAsync()
+    {
+        if (disposeConnection && Connection != null)
+        {
+            if (Connection.State == ConnectionState.Open)
+            {
+                await Connection.CloseAsync().ConfigureAwait(false);
+            }
+            
+            await Connection.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+}

--- a/Npgmq/NpgmqCommandFactory.cs
+++ b/Npgmq/NpgmqCommandFactory.cs
@@ -1,0 +1,31 @@
+using System.Data;
+using Npgsql;
+
+namespace Npgmq;
+
+internal class NpgmqCommandFactory
+{
+    private readonly NpgsqlConnection? _connection;
+    private readonly string? _connectionString;
+
+    public NpgmqCommandFactory(NpgsqlConnection connection)
+    {
+        _connection = connection;
+    }
+
+    public NpgmqCommandFactory(string connectionString)
+    {
+        _connectionString = connectionString;
+    }
+
+    public async Task<NpgmqCommand> CreateAsync(string commandText)
+    {
+        var connection = _connection ?? new NpgsqlConnection(_connectionString ?? throw new NpgmqException("No connection or connection string provided."));
+        if (connection.State != ConnectionState.Open)
+        {
+            await connection.OpenAsync().ConfigureAwait(false);
+        }
+        
+        return new NpgmqCommand(commandText, connection, _connection == null);
+    }
+}

--- a/Npgmq/NpgmqException.cs
+++ b/Npgmq/NpgmqException.cs
@@ -1,0 +1,24 @@
+namespace Npgmq;
+
+/// <summary>
+/// An exception thrown by Npgmq.
+/// </summary>
+public class NpgmqException : Exception
+{
+    /// <summary>
+    /// Create a new <see cref="NpgmqException"/>.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    public NpgmqException(string message) : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Create a new <see cref="NpgmqException"/>.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception.</param>
+    public NpgmqException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+}

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ public class MyMessageType
 }
 ```
 
-You can also send and read messages as JSON strings:
+You can send and read messages as JSON strings, like this:
 
 ```csharp   
 var msgId = await npgmq.SendAsync("my_queue", "{\"foo\":\"Test\",\"bar\":123}");
@@ -63,6 +63,13 @@ if (msg != null)
     Console.WriteLine($"Read message with id {msg.MsgId}: {msg.Message}");
     await npgmq.ArchiveAsync("my_queue", msg.MsgId);
 }
+```
+
+You can pass your own `NpgsqlConnection` to the `NpgmqClient` constructor, like this:
+
+```csharp
+using var myConnection = new NpgsqlConnection("<YOUR CONNECTION STRING HERE>");
+var npgmq = new NpgmqClient(myConnection);
 ```
 
 ## Database Connection

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "8.0.0",
+    "rollForward": "latestMajor",
+    "allowPrerelease": false
+  }
+}


### PR DESCRIPTION
Allow creating NpgmqClient using a connection object, to allow for better control over connection lifetime and to support transactions.

Added exception handling.