### PR TITLE
Provide default connection string for testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,6 @@ on:
 
 env:
   VERSION: 0.0.0
-  ConnectionStrings__Test: ${{ secrets.TEST_CONNECTION_STRING }}
 
 jobs:
   build:

--- a/Npgmq.Example/Program.cs
+++ b/Npgmq.Example/Program.cs
@@ -3,12 +3,14 @@ using Microsoft.Extensions.Configuration;
 using Npgmq;
 using Npgsql;
 
+const string defaultConnectionString = "Host=localhost;Username=postgres;Database=npgmq_test;";
+
 var configuration = new ConfigurationBuilder()
     .AddEnvironmentVariables()
     .AddUserSecrets(Assembly.GetExecutingAssembly())
     .Build();
 
-var connectionString = configuration.GetConnectionString("ExampleDB")!;
+var connectionString = configuration.GetConnectionString("ExampleDB") ?? defaultConnectionString;
 
 // Test Npgmq with connection string
 {

--- a/Npgmq.Test/NpgmqClientTest.cs
+++ b/Npgmq.Test/NpgmqClientTest.cs
@@ -8,6 +8,8 @@ namespace Npgmq.Test;
 
 public sealed class NpgmqClientTest : IDisposable
 {
+    private const string DefaultConnectionString = "Host=localhost;Username=postgres;Database=npgmq_test;";
+
     private static readonly string TestQueueName = $"test_{Guid.NewGuid():N}";
 
     private readonly string _connectionString;
@@ -28,7 +30,7 @@ public sealed class NpgmqClientTest : IDisposable
             .AddUserSecrets<NpgmqClientTest>()
             .Build();
 
-        _connectionString = configuration.GetConnectionString("Test")!;
+        _connectionString = configuration.GetConnectionString("Test") ?? DefaultConnectionString;
         _connection = new NpgsqlConnection(_connectionString);
         _sut = new NpgmqClient(_connection);
     }

--- a/Npgmq.Test/scripts/start-db.sh
+++ b/Npgmq.Test/scripts/start-db.sh
@@ -4,7 +4,10 @@ set -e
 PGMQ_VERSION=$1 
 
 docker run -d --name npgmq_test_db -p 5432:5432 --rm quay.io/tembo/tembo-local
-sleep 4
+
+until docker exec npgmq_test_db /bin/sh -c "pg_isready"; do
+  sleep 1
+done
 
 docker exec npgmq_test_db /bin/sh -c "psql -c \"CREATE DATABASE npgmq_test;\""
 

--- a/Npgmq.Test/scripts/stop-db.sh
+++ b/Npgmq.Test/scripts/stop-db.sh
@@ -2,3 +2,4 @@
 set -e
 
 docker stop npgmq_test_db
+docker rm npgmq_test_db


### PR DESCRIPTION
This eliminates the need to set a repository secret for the GitHub action, which fails when the action is running as the result of a pull request from a forked repo.

Also updated the start-db.sh script to use pg_ready to wait for postgres to become ready instead of sleeping for a predefined duration.