### PR TITLE
Add pgmq 1.7.0 Support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,26 +47,17 @@ jobs:
       - name: Test (latest pgmq version)
         run: Npgmq.Test/scripts/run-tests.sh
 
-      - name: Test (pgmq 1.4.5)
-        run: Npgmq.Test/scripts/run-tests.sh 1.4.5
+      - name: Test (pgmq 1.7.0)
+        run: Npgmq.Test/scripts/run-tests.sh 1.7.0
 
-      - name: Test (pgmq 1.3.3)
-        run: Npgmq.Test/scripts/run-tests.sh 1.3.3
+      - name: Test (pgmq 1.6.1)
+        run: Npgmq.Test/scripts/run-tests.sh 1.6.1
 
-      - name: Test (pgmq 1.2.1)
-        run: Npgmq.Test/scripts/run-tests.sh 1.2.1
+      - name: Test (pgmq 1.6.0)
+        run: Npgmq.Test/scripts/run-tests.sh 1.6.0
 
-      - name: Test (pgmq 1.1.1)
-        run: Npgmq.Test/scripts/run-tests.sh 1.1.1
-
-      - name: Test (pgmq 1.0.0)
-        run: Npgmq.Test/scripts/run-tests.sh 1.0.0
-
-      - name: Test (pgmq 0.33.1)
-        run: Npgmq.Test/scripts/run-tests.sh 0.33.1
-
-      - name: Test (pgmq 0.31.0)
-        run: Npgmq.Test/scripts/run-tests.sh 0.31.0
+      - name: Test (pgmq 1.5.1)
+        run: Npgmq.Test/scripts/run-tests.sh 1.5.1
 
       - name: Pack
         if: startsWith(github.ref, 'refs/tags/v')

--- a/Npgmq.Example/Program.cs
+++ b/Npgmq.Example/Program.cs
@@ -3,7 +3,7 @@ using Microsoft.Extensions.Configuration;
 using Npgmq;
 using Npgsql;
 
-const string defaultConnectionString = "Host=localhost;Username=postgres;Database=npgmq_test;";
+const string defaultConnectionString = "Host=localhost;Username=postgres;Password=postgres;Database=npgmq_test;";
 
 var configuration = new ConfigurationBuilder()
     .AddEnvironmentVariables()

--- a/Npgmq.Test/NpgmqClientTest.cs
+++ b/Npgmq.Test/NpgmqClientTest.cs
@@ -8,7 +8,7 @@ namespace Npgmq.Test;
 
 public sealed class NpgmqClientTest : IDisposable
 {
-    private const string DefaultConnectionString = "Host=localhost;Username=postgres;Database=npgmq_test;";
+    private const string DefaultConnectionString = "Host=localhost;Username=postgres;Password=postgres;Database=npgmq_test;";
 
     private static readonly string TestQueueName = $"test_{Guid.NewGuid():N}";
 
@@ -228,10 +228,24 @@ public sealed class NpgmqClientTest : IDisposable
         Assert.Equal(1, await _connection.ExecuteScalarAsync<int>("SELECT count(*) FROM pgmq.meta WHERE queue_name = @queueName;", new { queueName = TestQueueName }));
 
         // Act
-        await _sut.DropQueueAsync(TestQueueName);
+        var result = await _sut.DropQueueAsync(TestQueueName);
 
         // Assert
+        Assert.True(result);
         Assert.Equal(0, await _connection.ExecuteScalarAsync<int>("SELECT count(*) FROM pgmq.meta WHERE queue_name = @queueName;", new { queueName = TestQueueName }));
+    }
+
+    [Fact]
+    public async Task DropQueueAsync_should_return_false_if_queue_does_not_exist()
+    {
+        // Arrange
+        await ResetTestQueueAsync();
+
+        // Act
+        var result = await _sut.DropQueueAsync("some_nonexistent_queue");
+
+        // Assert
+        Assert.False(result);
     }
 
     [Fact]
@@ -240,6 +254,7 @@ public sealed class NpgmqClientTest : IDisposable
         try
         {
             // Arrange
+            await ResetTestQueueAsync();
             await _connection.ExecuteAsync("DROP EXTENSION IF EXISTS pgmq CASCADE;");
             Assert.Equal(0, await _connection.ExecuteScalarAsync<int>("SELECT count(*) FROM pg_extension WHERE extname = 'pgmq';"));
 
@@ -282,6 +297,7 @@ public sealed class NpgmqClientTest : IDisposable
         try
         {
             // Arrange
+            await ResetTestQueueAsync();
             await _connection.ExecuteAsync("DROP EXTENSION IF EXISTS pgmq CASCADE;");
             Assert.Equal(0, await _connection.ExecuteScalarAsync<int>("SELECT count(*) FROM pg_extension WHERE extname = 'pgmq';"));
 
@@ -458,6 +474,43 @@ public sealed class NpgmqClientTest : IDisposable
             Baz = DateTimeOffset.Parse("2023-09-01T01:23:45-04:00")
         });
         Assert.Equal(0, await _connection.ExecuteScalarAsync<long>($"SELECT count(*) FROM pgmq.q_{TestQueueName};"));
+        Assert.Equal(0, await _connection.ExecuteScalarAsync<long>($"SELECT count(*) FROM pgmq.a_{TestQueueName};"));
+    }
+
+    [SkippableTheory]
+    [InlineData(1, 1, 2)]
+    [InlineData(2, 2, 1)]
+    [InlineData(3, 3, 0)]
+    [InlineData(4, 3, 0)]
+    public async Task PopAsync_should_read_and_delete_multiple_messages(int qty, int expectedCount, int expectedRemaining)
+    {
+        Skip.IfNot(await IsMinPgmqVersion("1.7.0"), "requires pgmq 1.7.0 or later.");
+
+        // Arrange
+        await ResetTestQueueAsync();
+
+        // Act
+        var msgIds = new List<long>
+        {
+            await _sut.SendAsync(TestQueueName, new TestMessage { Foo = 1 }),
+            await _sut.SendAsync(TestQueueName, new TestMessage { Foo = 2 }),
+            await _sut.SendAsync(TestQueueName, new TestMessage { Foo = 3 })
+        };
+
+        var results = await _sut.PopAsync<TestMessage>(TestQueueName, qty);
+
+        // Assert
+        Assert.Equal(expectedCount, results.Count);
+        for (var i = 0; i < expectedCount; i++)
+        {
+            var r = results[i];
+            Assert.Equal(msgIds[i], r.MsgId);
+            Assert.True(r.EnqueuedAt < DateTimeOffset.UtcNow);
+            Assert.Equal(TimeSpan.Zero, r.EnqueuedAt.Offset);
+            Assert.Equal(0, r.ReadCt);
+            r.Message.ShouldDeepEqual(new TestMessage { Foo = i + 1 });
+        }
+        Assert.Equal(expectedRemaining, await _connection.ExecuteScalarAsync<long>($"SELECT count(*) FROM pgmq.q_{TestQueueName};"));
         Assert.Equal(0, await _connection.ExecuteScalarAsync<long>($"SELECT count(*) FROM pgmq.a_{TestQueueName};"));
     }
 

--- a/Npgmq.Test/scripts/start-db.sh
+++ b/Npgmq.Test/scripts/start-db.sh
@@ -3,7 +3,13 @@ set -e
 
 PGMQ_VERSION=$1 
 
-docker run -d --name npgmq_test_db -p 5432:5432 --rm quay.io/tembo/tembo-local
+if [ -n "$PGMQ_VERSION" ] && [ "$PGMQ_VERSION" != "latest" ]; then
+  TAG="v${PGMQ_VERSION}"
+else
+  TAG="latest"
+fi
+
+docker run -d --name npgmq_test_db -e POSTGRES_PASSWORD=postgres -p 5432:5432 ghcr.io/pgmq/pg17-pgmq:"${TAG}"
 
 until docker exec npgmq_test_db /bin/sh -c "pg_isready"; do
   sleep 1
@@ -11,9 +17,4 @@ done
 
 docker exec npgmq_test_db /bin/sh -c "psql -c \"CREATE DATABASE npgmq_test;\""
 
-if [ -z "$PGMQ_VERSION" ] || [ "$PGMQ_VERSION" = "latest" ]; then
-  docker exec npgmq_test_db /bin/sh -c "trunk install pgmq"
-else
-  docker exec npgmq_test_db /bin/sh -c "trunk install pgmq --version=${PGMQ_VERSION}"
-fi
 docker exec npgmq_test_db /bin/sh -c "psql -d npgmq_test -c \"CREATE EXTENSION pgmq CASCADE;\""

--- a/Npgmq/INpgmqClient.cs
+++ b/Npgmq/INpgmqClient.cs
@@ -60,7 +60,8 @@ public interface INpgmqClient
     /// </summary>
     /// <param name="queueName">The queue name.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    Task DropQueueAsync(string queueName, CancellationToken cancellationToken = default);
+    /// <returns>True if the queue was dropped, false if the queue did not exist.</returns>
+    Task<bool> DropQueueAsync(string queueName, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Create pgmq extension, if it does not exist.
@@ -118,6 +119,19 @@ public interface INpgmqClient
     /// <typeparam name="T">The message type.</typeparam>
     /// <returns>The message read, or null if no message was read.</returns>
     Task<NpgmqMessage<T>?> PopAsync<T>(string queueName, CancellationToken cancellationToken = default) where T : class;
+
+    /// <summary>
+    /// Read up to the specified number of messages from a queue and immediately delete them.
+    /// </summary>
+    /// <remarks>
+    /// Requires pgmq 1.7.0 or later.
+    /// </remarks>
+    /// <param name="queueName">The queue name.</param>
+    /// <param name="qty">The number of messages to pop.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <typeparam name="T">The message type.</typeparam>
+    /// <returns>The messages read.</returns>
+    Task<List<NpgmqMessage<T>>> PopAsync<T>(string queueName, int qty, CancellationToken cancellationToken = default) where T : class;
 
     /// <summary>
     /// Purge a queue.

--- a/Npgmq/NpgmqClient.cs
+++ b/Npgmq/NpgmqClient.cs
@@ -160,7 +160,7 @@ public class NpgmqClient : INpgmqClient
         }
     }
 
-    public async Task DropQueueAsync(string queueName, CancellationToken cancellationToken = default)
+    public async Task<bool> DropQueueAsync(string queueName, CancellationToken cancellationToken = default)
     {
         try
         {
@@ -168,7 +168,8 @@ public class NpgmqClient : INpgmqClient
             await using (cmd.ConfigureAwait(false))
             {
                 cmd.Parameters.AddWithValue("@queue_name", queueName);
-                await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+                var result = await cmd.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+                return result is not null && Convert.ToBoolean(result);
             }
         }
         catch (Exception ex)
@@ -297,6 +298,28 @@ public class NpgmqClient : INpgmqClient
                 {
                     var result = await ReadMessagesAsync<T>(reader, cancellationToken).ConfigureAwait(false);
                     return result.SingleOrDefault();
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            throw new NpgmqException($"Failed to pop queue {queueName}.", ex);
+        }
+    }
+
+    public async Task<List<NpgmqMessage<T>>> PopAsync<T>(string queueName, int qty, CancellationToken cancellationToken = default) where T : class
+    {
+        try
+        {
+            var cmd = await _commandFactory.CreateAsync("SELECT msg_id, read_ct, enqueued_at, vt, message FROM pgmq.pop(@queue_name, @qty);", cancellationToken).ConfigureAwait(false);
+            await using (cmd.ConfigureAwait(false))
+            {
+                cmd.Parameters.AddWithValue("@queue_name", queueName);
+                cmd.Parameters.AddWithValue("@qty", qty);
+                var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+                await using (reader.ConfigureAwait(false))
+                {
+                    return await ReadMessagesAsync<T>(reader, cancellationToken).ConfigureAwait(false);
                 }
             }
         }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Npgmq
 
-A .NET client for [Postgres Message Queue](https://github.com/tembo-io/pgmq) (PGMQ).
+A .NET client for [Postgres Message Queue](https://github.com/pgmq/pgmq) (PGMQ).
 
 [![Build](https://github.com/brianpursley/Npgmq/actions/workflows/build.yml/badge.svg)](https://github.com/brianpursley/Npgmq/actions/workflows/build.yml)
 [![Nuget](https://img.shields.io/nuget/v/Npgmq)](https://www.nuget.org/packages/Npgmq/)


### PR DESCRIPTION
* Overload PopAsync() to accept quantity ("pop many" feature) - requires pgmq 1.7.0
* Changed DropQueueAsync() to return boolean indicating whether the queue existed or not
* Use pgmq's pre-built containers for testing
* Fix unit test flake when re-initializing pgmq
* Update build to test versions 1.5.1 -> 1.7.0 (because pgmq hasn't publish images for older versions)