### PR TITLE
feat: Add SetVtBatchAsync

### DIFF
--- a/Npgmq.Test/NpgmqClientTest.cs
+++ b/Npgmq.Test/NpgmqClientTest.cs
@@ -873,6 +873,36 @@ public sealed class NpgmqClientTest : IDisposable
     }
 
     [SkippableFact]
+    public async Task SetVtBatchAsync_should_change_vt_for_multiple_messages()
+    {
+        Skip.IfNot(await IsMinPgmqVersion("1.8.0"), "requires pgmq 1.8.0 or later.");
+
+        // Arrange
+        await ResetTestQueueAsync();
+        var msgId1 = await _sut.SendAsync(TestQueueName, new TestMessage { Foo = 1 });
+        var msgId2 = await _sut.SendAsync(TestQueueName, new TestMessage { Foo = 2 });
+        var message1 = await _sut.ReadAsync<TestMessage>(TestQueueName);
+        Assert.NotNull(message1);
+        Assert.Equal(msgId1, message1.MsgId);
+        var message2 = await _sut.ReadAsync<TestMessage>(TestQueueName);
+        Assert.NotNull(message2);
+        Assert.Equal(msgId2, message2.MsgId);
+        Assert.Null(await _sut.ReadAsync<TestMessage>(TestQueueName));
+
+        // Act
+        await _sut.SetVtBatchAsync(TestQueueName, new List<long> { msgId1, msgId2 }, -60);
+        message1 = await _sut.ReadAsync<TestMessage>(TestQueueName);
+        message2 = await _sut.ReadAsync<TestMessage>(TestQueueName);
+
+        // Assert
+        Assert.NotNull(message1);
+        Assert.Equal(msgId1, message1.MsgId);
+        Assert.NotNull(message2);
+        Assert.Equal(msgId2, message2.MsgId);
+        Assert.Null(await _sut.ReadAsync<TestMessage>(TestQueueName));
+    }
+
+    [SkippableFact]
     public async Task GetMetricsAsync_should_return_metrics_for_a_single_queue()
     {
         Skip.IfNot(await IsMinPgmqVersion("0.33.1"), "PGMQ versions before 0.33.1 have a bug in the total messages calculation.");

--- a/Npgmq/INpgmqClient.cs
+++ b/Npgmq/INpgmqClient.cs
@@ -234,6 +234,15 @@ public interface INpgmqClient
     Task SetVtAsync(string queueName, long msgId, int vtOffset, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Adjust the Vt of multiple existing messages.
+    /// </summary>
+    /// <param name="queueName">The queue name.</param>
+    /// <param name="msgIds">The message IDs.</param>
+    /// <param name="vtOffset">The number of seconds to be added to the current Vt.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    Task SetVtBatchAsync(string queueName, IEnumerable<long> msgIds, int vtOffset, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Get metrics for all queues.
     /// </summary>
     /// <param name="cancellationToken">The cancellation token.</param>

--- a/Npgmq/NpgmqClient.cs
+++ b/Npgmq/NpgmqClient.cs
@@ -478,6 +478,25 @@ public class NpgmqClient : INpgmqClient
         }
     }
 
+    public async Task SetVtBatchAsync(string queueName, IEnumerable<long> msgIds, int vtOffset, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var cmd = await _commandFactory.CreateAsync("SELECT pgmq.set_vt(@queue_name, @msg_ids, @vt_offset);", cancellationToken).ConfigureAwait(false);
+            await using (cmd.ConfigureAwait(false))
+            {
+                cmd.Parameters.AddWithValue("@queue_name", queueName);
+                cmd.Parameters.AddWithValue("@msg_ids", msgIds.ToArray());
+                cmd.Parameters.AddWithValue("@vt_offset", vtOffset);
+                await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+        catch (Exception ex)
+        {
+            throw new NpgmqException($"Failed to set VT for messages from queue {queueName}.", ex);
+        }
+    }
+
     public async Task<List<NpgmqMetricsResult>> GetMetricsAsync(CancellationToken cancellationToken = default)
     {
         try


### PR DESCRIPTION
## Summary
Adds `SetVtBatchAsync` method to `INpgmqClient` and `NpgmqClient` to support batch visibility timeout functionality introduced in `pgmq 1.8.0`. Includes a new test case `SetVtBatchAsync_should_change_vt_for_multiple_messages` to verify its behavior. 
  


 <br /> 


 > Want me to make any changes? Add a review or comment with `@tembo` and i'll get back to work! 


 [![tembo.io](https://internal.tembo.io/static/view/tembo.svg?v=4)](https://app.tembo.io/tasks/88821d5b-c5d8-4519-93f7-bf0e68e2120f)  [![app.tembo.io](https://internal.tembo.io/public/agent-button/claudeCode:claude-4-5-sonnet?v=1)](https://app.tembo.io/settings/agents)