### PR TITLE
Pgmq 1.10 changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Test (latest pgmq version)
         run: Npgmq.Test/scripts/run-tests.sh
 
+      - name: Test (pgmq 1.10.0)
+        run: Npgmq.Test/scripts/run-tests.sh 1.10.0
+
       - name: Test (pgmq 1.9.0)
         run: Npgmq.Test/scripts/run-tests.sh 1.9.0
 

--- a/Npgmq.Test/NpgmqClientStressTest.cs
+++ b/Npgmq.Test/NpgmqClientStressTest.cs
@@ -1,5 +1,4 @@
 using System.Collections.Concurrent;
-using Npgsql;
 
 namespace Npgmq.Test;
 

--- a/Npgmq.Test/NpgmqClientTest.cs
+++ b/Npgmq.Test/NpgmqClientTest.cs
@@ -1309,6 +1309,35 @@ public sealed class NpgmqClientTest : IClassFixture<PostgresFixture>, IAsyncLife
     }
 
     [SkippableFact]
+    public async Task SetVtAsync_should_change_vt_for_a_message_using_timestamp()
+    {
+        Skip.IfNot(await IsMinPgmqVersion("1.10.0"), "requires pgmq 1.10.0 or later.");
+
+        // Arrange
+        await _sut.CreateQueueAsync(_testQueueName);
+        var msgId = await _sut.SendAsync(_testQueueName, new TestMessage { Foo = 1 });
+        var originalMessages = await _sut.ReadBatchAsync<TestMessage>(_testQueueName);
+        Assert.Equal(msgId, originalMessages.Single().MsgId);
+        // Confirm there is nothing else to read
+        var visibleMessages = await _sut.ReadBatchAsync<TestMessage>(_testQueueName);
+        Assert.Empty(visibleMessages);
+
+        // Act
+        var vt = DateTimeOffset.UtcNow.AddSeconds(-60).TruncateToMicroseconds();
+        await _sut.SetVtAsync(_testQueueName, msgId, vt);
+        var storedVt = (await _connection.QuerySingleAsync<DateTime>($"SELECT vt FROM pgmq.q_{_testQueueName} WHERE msg_id = @msgId;", new { msgId }))
+            .ToDateTimeOffset()
+            .TruncateToMicroseconds();
+        visibleMessages = await _sut.ReadBatchAsync<TestMessage>(_testQueueName);
+
+        // Assert
+        Assert.Equal(vt, storedVt);
+        Assert.Equal(msgId, visibleMessages.Single().MsgId);
+        // After reading, there should be no more visible messages
+        Assert.Empty(await _sut.ReadBatchAsync<TestMessage>(_testQueueName));
+    }
+
+    [SkippableFact]
     public async Task SetVtBatchAsync_should_change_vt_for_multiple_messages()
     {
         Skip.IfNot(await IsMinPgmqVersion("1.8.0"), "requires pgmq 1.8.0 or later.");
@@ -1337,6 +1366,46 @@ public sealed class NpgmqClientTest : IClassFixture<PostgresFixture>, IAsyncLife
 
         // Assert
         Assert.Equal(expectedMsgIds, actualMsgIds);
+        Assert.Equal(2, visibleMessages.Count);
+        Assert.Contains(visibleMessages, msg => msg.MsgId == msgId1);
+        Assert.Contains(visibleMessages, msg => msg.MsgId == msgId2);
+        // After reading, there should be no more visible messages
+        Assert.Empty(await _sut.ReadBatchAsync<TestMessage>(_testQueueName));
+    }
+
+    [SkippableFact]
+    public async Task SetVtBatchAsync_should_change_vt_for_multiple_messages_using_timestamp()
+    {
+        Skip.IfNot(await IsMinPgmqVersion("1.10.0"), "requires pgmq 1.10.0 or later.");
+
+        // Arrange
+        await _sut.CreateQueueAsync(_testQueueName);
+        var msgId1 = await _sut.SendAsync(_testQueueName, new TestMessage
+        {
+            Foo = 1
+        });
+        var msgId2 = await _sut.SendAsync(_testQueueName, new TestMessage
+        {
+            Foo = 2
+        });
+        var originalMessages = await _sut.ReadBatchAsync<TestMessage>(_testQueueName);
+        Assert.Equal(2, originalMessages.Count);
+        // Confirm there is nothing else to read
+        var visibleMessages = await _sut.ReadBatchAsync<TestMessage>(_testQueueName);
+        Assert.Empty(visibleMessages);
+
+        // Act
+        var expectedMsgIds = new List<long> { msgId1, msgId2 };
+        var vt = DateTimeOffset.UtcNow.AddSeconds(-60).TruncateToMicroseconds();
+        var actualMsgIds = await _sut.SetVtBatchAsync(_testQueueName, expectedMsgIds, vt);
+        var storedVts = (await _connection.QueryAsync<DateTime>($"SELECT vt FROM pgmq.q_{_testQueueName} WHERE msg_id = ANY(@msgIds) ORDER BY msg_id;", new { msgIds = expectedMsgIds }))
+            .Select(x => x.ToDateTimeOffset().TruncateToMicroseconds())
+            .ToList();
+        visibleMessages = await _sut.ReadBatchAsync<TestMessage>(_testQueueName);
+
+        // Assert
+        Assert.Equal(expectedMsgIds, actualMsgIds);
+        Assert.All(storedVts, storedVt => Assert.Equal(vt, storedVt));
         Assert.Equal(2, visibleMessages.Count);
         Assert.Contains(visibleMessages, msg => msg.MsgId == msgId1);
         Assert.Contains(visibleMessages, msg => msg.MsgId == msgId2);

--- a/Npgmq/INpgmqClient.cs
+++ b/Npgmq/INpgmqClient.cs
@@ -341,7 +341,7 @@ public interface INpgmqClient
     /// </remarks>
     /// <param name="queueName">The queue name.</param>
     /// <param name="msgId">The message ID.</param>
-    /// <param name="vt">The new vt.</param>
+    /// <param name="vt">The new timestamp at which the message becomes visible.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     Task SetVtAsync(string queueName, long msgId, DateTimeOffset vt, CancellationToken cancellationToken = default);
 
@@ -367,7 +367,7 @@ public interface INpgmqClient
     /// </remarks>
     /// <param name="queueName">The queue name.</param>
     /// <param name="msgIds">The message IDs.</param>
-    /// <param name="vt">The new vt.</param>
+    /// <param name="vt">The new timestamp at which the messages become visible.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>List of IDs that were updated.</returns>
     Task<List<long>> SetVtBatchAsync(string queueName, IEnumerable<long> msgIds, DateTimeOffset vt,

--- a/Npgmq/INpgmqClient.cs
+++ b/Npgmq/INpgmqClient.cs
@@ -334,6 +334,18 @@ public interface INpgmqClient
     Task SetVtAsync(string queueName, long msgId, int vtOffset, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Adjust the Vt of an existing message.
+    /// </summary>
+    /// <remarks>
+    /// Requires pgmq 1.10.0 or later.
+    /// </remarks>
+    /// <param name="queueName">The queue name.</param>
+    /// <param name="msgId">The message ID.</param>
+    /// <param name="vt">The new vt.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    Task SetVtAsync(string queueName, long msgId, DateTimeOffset vt, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Adjust the Vt of multiple existing messages.
     /// </summary>
     /// <remarks>
@@ -345,6 +357,20 @@ public interface INpgmqClient
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>List of IDs that were updated.</returns>
     Task<List<long>> SetVtBatchAsync(string queueName, IEnumerable<long> msgIds, int vtOffset,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Adjust the Vt of multiple existing messages.
+    /// </summary>
+    /// <remarks>
+    /// Requires pgmq 1.10.0 or later.
+    /// </remarks>
+    /// <param name="queueName">The queue name.</param>
+    /// <param name="msgIds">The message IDs.</param>
+    /// <param name="vt">The new vt.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>List of IDs that were updated.</returns>
+    Task<List<long>> SetVtBatchAsync(string queueName, IEnumerable<long> msgIds, DateTimeOffset vt,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/Npgmq/NpgmqClient.cs
+++ b/Npgmq/NpgmqClient.cs
@@ -863,7 +863,7 @@ public class NpgmqClient : INpgmqClient
             {
                 cmd.Parameters.AddWithValue("@queue_name", queueName);
                 cmd.Parameters.AddWithValue("@msg_id", msgId);
-                cmd.Parameters.AddWithValue("@vt", vt);
+                cmd.Parameters.AddWithValue("@vt", vt.ToUniversalTime());
                 await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
             }
         }
@@ -918,7 +918,7 @@ public class NpgmqClient : INpgmqClient
             {
                 cmd.Parameters.AddWithValue("@queue_name", queueName);
                 cmd.Parameters.AddWithValue("@msg_ids", NpgsqlDbType.Array | NpgsqlDbType.Bigint, msgIds.ToArray());
-                cmd.Parameters.AddWithValue("@vt", vt);
+                cmd.Parameters.AddWithValue("@vt", vt.ToUniversalTime());
                 var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
                 await using (reader.ConfigureAwait(false))
                 {

--- a/Npgmq/NpgmqClient.cs
+++ b/Npgmq/NpgmqClient.cs
@@ -835,12 +835,35 @@ public class NpgmqClient : INpgmqClient
     {
         try
         {
-            var cmd = await _commandFactory.CreateAsync("SELECT pgmq.set_vt(@queue_name, @msg_id, @vt_offset);", cancellationToken).ConfigureAwait(false);
+            var cmd = await _commandFactory.CreateAsync("SELECT pgmq.set_vt(@queue_name, @msg_id, @vt);", cancellationToken).ConfigureAwait(false);
             await using (cmd.ConfigureAwait(false))
             {
                 cmd.Parameters.AddWithValue("@queue_name", queueName);
                 cmd.Parameters.AddWithValue("@msg_id", msgId);
-                cmd.Parameters.AddWithValue("@vt_offset", vtOffset);
+                cmd.Parameters.AddWithValue("@vt", vtOffset);
+                await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new NpgmqException($"Failed to set VT for message {msgId} in queue {queueName}.", ex);
+        }
+    }
+
+    public async Task SetVtAsync(string queueName, long msgId, DateTimeOffset vt, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var cmd = await _commandFactory.CreateAsync("SELECT pgmq.set_vt(@queue_name, @msg_id, @vt);", cancellationToken).ConfigureAwait(false);
+            await using (cmd.ConfigureAwait(false))
+            {
+                cmd.Parameters.AddWithValue("@queue_name", queueName);
+                cmd.Parameters.AddWithValue("@msg_id", msgId);
+                cmd.Parameters.AddWithValue("@vt", vt);
                 await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
             }
         }
@@ -858,12 +881,44 @@ public class NpgmqClient : INpgmqClient
     {
         try
         {
-            var cmd = await _commandFactory.CreateAsync("SELECT msg_id FROM pgmq.set_vt(@queue_name, @msg_ids, @vt_offset);", cancellationToken).ConfigureAwait(false);
+            var cmd = await _commandFactory.CreateAsync("SELECT msg_id FROM pgmq.set_vt(@queue_name, @msg_ids, @vt);", cancellationToken).ConfigureAwait(false);
             await using (cmd.ConfigureAwait(false))
             {
                 cmd.Parameters.AddWithValue("@queue_name", queueName);
                 cmd.Parameters.AddWithValue("@msg_ids", NpgsqlDbType.Array | NpgsqlDbType.Bigint, msgIds.ToArray());
-                cmd.Parameters.AddWithValue("@vt_offset", vtOffset);
+                cmd.Parameters.AddWithValue("@vt", vtOffset);
+                var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+                await using (reader.ConfigureAwait(false))
+                {
+                    var result = new List<long>();
+                    while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                    {
+                        result.Add(reader.GetInt64(0));
+                    }
+                    return result;
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new NpgmqException($"Failed to set VT for messages in queue {queueName}.", ex);
+        }
+    }
+
+    public async Task<List<long>> SetVtBatchAsync(string queueName, IEnumerable<long> msgIds, DateTimeOffset vt, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var cmd = await _commandFactory.CreateAsync("SELECT msg_id FROM pgmq.set_vt(@queue_name, @msg_ids, @vt);", cancellationToken).ConfigureAwait(false);
+            await using (cmd.ConfigureAwait(false))
+            {
+                cmd.Parameters.AddWithValue("@queue_name", queueName);
+                cmd.Parameters.AddWithValue("@msg_ids", NpgsqlDbType.Array | NpgsqlDbType.Bigint, msgIds.ToArray());
+                cmd.Parameters.AddWithValue("@vt", vt);
                 var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
                 await using (reader.ConfigureAwait(false))
                 {

--- a/Npgmq/NpgmqCommand.cs
+++ b/Npgmq/NpgmqCommand.cs
@@ -1,4 +1,3 @@
-using System.Data;
 using Npgsql;
 
 namespace Npgmq;
@@ -6,11 +5,14 @@ namespace Npgmq;
 internal class NpgmqCommand(string commandText, NpgsqlConnection connection, bool disposeConnection)
     : NpgsqlCommand(commandText, connection)
 {
+    // Track whether the connection has been disposed to avoid double-disposal.
+    private int _connectionHasBeenDisposed;
+
     public override async ValueTask DisposeAsync()
     {
         try
         {
-            if (disposeConnection && Connection != null)
+            if (disposeConnection && Connection != null && Interlocked.CompareExchange(ref _connectionHasBeenDisposed, 1, 0) == 0)
             {
                 await Connection.DisposeAsync().ConfigureAwait(false);
                 Connection = null;
@@ -26,7 +28,7 @@ internal class NpgmqCommand(string commandText, NpgsqlConnection connection, boo
     {
         try
         {
-            if (disposing && disposeConnection && Connection != null)
+            if (disposeConnection && Connection != null && Interlocked.CompareExchange(ref _connectionHasBeenDisposed, 1, 0) == 0)
             {
                 Connection.Dispose();
                 Connection = null;

--- a/Npgmq/NpgmqCommand.cs
+++ b/Npgmq/NpgmqCommand.cs
@@ -16,6 +16,7 @@ internal class NpgmqCommand(string commandText, NpgsqlConnection connection, boo
             }
 
             await Connection.DisposeAsync().ConfigureAwait(false);
+            Connection = null;
         }
 
         await base.DisposeAsync().ConfigureAwait(false);
@@ -31,6 +32,7 @@ internal class NpgmqCommand(string commandText, NpgsqlConnection connection, boo
             }
 
             Connection.Dispose();
+            Connection = null;
         }
 
         base.Dispose(disposing);

--- a/Npgmq/NpgmqCommand.cs
+++ b/Npgmq/NpgmqCommand.cs
@@ -6,18 +6,19 @@ namespace Npgmq;
 internal class NpgmqCommand(string commandText, NpgsqlConnection connection, bool disposeConnection)
     : NpgsqlCommand(commandText, connection)
 {
-    public override async ValueTask DisposeAsync()
+    protected override void Dispose(bool disposing)
     {
-        await base.DisposeAsync();
-
-        if (disposeConnection && Connection != null)
+        if (disposing && disposeConnection && Connection != null)
         {
             if (Connection.State == ConnectionState.Open)
             {
-                await Connection.CloseAsync().ConfigureAwait(false);
+                Connection.Close();
             }
 
-            await Connection.DisposeAsync().ConfigureAwait(false);
+            Connection.Dispose();
+            Connection = null;
         }
+
+        base.Dispose(disposing);
     }
 }

--- a/Npgmq/NpgmqCommand.cs
+++ b/Npgmq/NpgmqCommand.cs
@@ -6,6 +6,21 @@ namespace Npgmq;
 internal class NpgmqCommand(string commandText, NpgsqlConnection connection, bool disposeConnection)
     : NpgsqlCommand(commandText, connection)
 {
+    public override async ValueTask DisposeAsync()
+    {
+        if (disposeConnection && Connection != null)
+        {
+            if (Connection.State == ConnectionState.Open)
+            {
+                await Connection.CloseAsync().ConfigureAwait(false);
+            }
+
+            await Connection.DisposeAsync().ConfigureAwait(false);
+        }
+
+        await base.DisposeAsync().ConfigureAwait(false);
+    }
+
     protected override void Dispose(bool disposing)
     {
         if (disposing && disposeConnection && Connection != null)
@@ -16,7 +31,6 @@ internal class NpgmqCommand(string commandText, NpgsqlConnection connection, boo
             }
 
             Connection.Dispose();
-            Connection = null;
         }
 
         base.Dispose(disposing);

--- a/Npgmq/NpgmqCommand.cs
+++ b/Npgmq/NpgmqCommand.cs
@@ -15,7 +15,6 @@ internal class NpgmqCommand(string commandText, NpgsqlConnection connection, boo
         if (disposeConnection && Connection != null && Interlocked.CompareExchange(ref _connectionHasBeenDisposed, 1, 0) == 0)
         {
             await Connection.DisposeAsync().ConfigureAwait(false);
-            Connection = null;
         }
     }
 
@@ -26,7 +25,6 @@ internal class NpgmqCommand(string commandText, NpgsqlConnection connection, boo
         if (disposing && disposeConnection && Connection != null && Interlocked.CompareExchange(ref _connectionHasBeenDisposed, 1, 0) == 0)
         {
             Connection.Dispose();
-            Connection = null;
         }
     }
 }

--- a/Npgmq/NpgmqCommand.cs
+++ b/Npgmq/NpgmqCommand.cs
@@ -8,33 +8,43 @@ internal class NpgmqCommand(string commandText, NpgsqlConnection connection, boo
 {
     public override async ValueTask DisposeAsync()
     {
-        if (disposeConnection && Connection != null)
+        try
         {
-            if (Connection.State == ConnectionState.Open)
+            if (disposeConnection && Connection != null)
             {
-                await Connection.CloseAsync().ConfigureAwait(false);
+                if (Connection.State == ConnectionState.Open)
+                {
+                    await Connection.CloseAsync().ConfigureAwait(false);
+                }
+
+                await Connection.DisposeAsync().ConfigureAwait(false);
+                Connection = null;
             }
-
-            await Connection.DisposeAsync().ConfigureAwait(false);
-            Connection = null;
         }
-
-        await base.DisposeAsync().ConfigureAwait(false);
+        finally
+        {
+            await base.DisposeAsync().ConfigureAwait(false);
+        }
     }
 
     protected override void Dispose(bool disposing)
     {
-        if (disposing && disposeConnection && Connection != null)
+        try
         {
-            if (Connection.State == ConnectionState.Open)
+            if (disposing && disposeConnection && Connection != null)
             {
-                Connection.Close();
+                if (Connection.State == ConnectionState.Open)
+                {
+                    Connection.Close();
+                }
+
+                Connection.Dispose();
+                Connection = null;
             }
-
-            Connection.Dispose();
-            Connection = null;
         }
-
-        base.Dispose(disposing);
+        finally
+        {
+            base.Dispose(disposing);
+        }
     }
 }

--- a/Npgmq/NpgmqCommand.cs
+++ b/Npgmq/NpgmqCommand.cs
@@ -12,11 +12,6 @@ internal class NpgmqCommand(string commandText, NpgsqlConnection connection, boo
         {
             if (disposeConnection && Connection != null)
             {
-                if (Connection.State == ConnectionState.Open)
-                {
-                    await Connection.CloseAsync().ConfigureAwait(false);
-                }
-
                 await Connection.DisposeAsync().ConfigureAwait(false);
                 Connection = null;
             }
@@ -33,11 +28,6 @@ internal class NpgmqCommand(string commandText, NpgsqlConnection connection, boo
         {
             if (disposing && disposeConnection && Connection != null)
             {
-                if (Connection.State == ConnectionState.Open)
-                {
-                    Connection.Close();
-                }
-
                 Connection.Dispose();
                 Connection = null;
             }

--- a/Npgmq/NpgmqCommand.cs
+++ b/Npgmq/NpgmqCommand.cs
@@ -11,7 +11,7 @@ internal class NpgmqCommand(string commandText, NpgsqlConnection connection, boo
     public override async ValueTask DisposeAsync()
     {
         await base.DisposeAsync().ConfigureAwait(false);
-        
+
         if (disposeConnection && Connection != null && Interlocked.CompareExchange(ref _connectionHasBeenDisposed, 1, 0) == 0)
         {
             await Connection.DisposeAsync().ConfigureAwait(false);

--- a/Npgmq/NpgmqCommand.cs
+++ b/Npgmq/NpgmqCommand.cs
@@ -10,33 +10,23 @@ internal class NpgmqCommand(string commandText, NpgsqlConnection connection, boo
 
     public override async ValueTask DisposeAsync()
     {
-        try
+        await base.DisposeAsync().ConfigureAwait(false);
+        
+        if (disposeConnection && Connection != null && Interlocked.CompareExchange(ref _connectionHasBeenDisposed, 1, 0) == 0)
         {
-            if (disposeConnection && Connection != null && Interlocked.CompareExchange(ref _connectionHasBeenDisposed, 1, 0) == 0)
-            {
-                await Connection.DisposeAsync().ConfigureAwait(false);
-                Connection = null;
-            }
-        }
-        finally
-        {
-            await base.DisposeAsync().ConfigureAwait(false);
+            await Connection.DisposeAsync().ConfigureAwait(false);
+            Connection = null;
         }
     }
 
     protected override void Dispose(bool disposing)
     {
-        try
+        base.Dispose(disposing);
+
+        if (disposing && disposeConnection && Connection != null && Interlocked.CompareExchange(ref _connectionHasBeenDisposed, 1, 0) == 0)
         {
-            if (disposeConnection && Connection != null && Interlocked.CompareExchange(ref _connectionHasBeenDisposed, 1, 0) == 0)
-            {
-                Connection.Dispose();
-                Connection = null;
-            }
-        }
-        finally
-        {
-            base.Dispose(disposing);
+            Connection.Dispose();
+            Connection = null;
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -15,17 +15,26 @@ dotnet add package Npgmq
 
 ## Recommended Usage (TL;DR)
 
-For most applications, use NpgsqlDataSource to create an NpgmqClient.
+### Creating NpgmqClient
 
+When creating an NpgmqClient instance, the recommended approach is to use an NpgsqlDataSource. This provides the best connection pooling, performance, and safety.
 ```csharp
 await using var dataSource = NpgsqlDataSource.Create("<YOUR CONNECTION STRING HERE>");
 var npgmq = new NpgmqClient(dataSource);
 ```
 
-This provides the best connection pooling, performance, and safety.
-
-You can also construct the client with a connection string or an existing NpgsqlConnection, but those options have tradeoffs. 
+You can also construct the client with a connection string or an existing NpgsqlConnection, but those options have tradeoffs.
 See [Database Connection](#database-connection) below.
+
+### Using Dependency Injection (ASP.NET Core)
+
+For ASP.NET Core applications, register NpgmqClient in the DI container using one of the following methods:
+```csharp
+builder.Services.AddNpgmqClient("<YOUR CONNECTION STRING HERE>");
+```
+```csharp
+builder.Services.AddNpgmqClient(); // If you already have an NpgsqlDataSource registered
+```
 
 ## Basic Example
 
@@ -61,6 +70,12 @@ public class MyMessageType
 }
 ```
 
+### Additional Examples
+
+For more complete examples, see the following projects included in this repository:
+* [Npgmq.Example.Console](./Npgmq.Example.Console)
+* [Npgmq.Example.Web](./Npgmq.Example.Web)
+
 ## JSON Messages (Custom Serialization)
 
 If you want full control over JSON serialization, you can send and receive messages as string:
@@ -80,7 +95,6 @@ if (msg != null)
 Important:  
 * When sending messages as string, the value must contain valid JSON.  
 * NpgmqClient does not validate or escape string messages. Invalid JSON will cause the database call to fail.
-
 
 ## Database Connection
 


### PR DESCRIPTION
This pull request adds support for setting the "vt" (visibility timeout) of messages using a timestamp (DateTimeOffset), which requires pgmq version 1.10.0 or later. It updates both the client interface and implementation, adds new tests for this functionality, and improves documentation and test coverage. It also includes a fix for proper resource disposal in the custom command class and enhances the README with better usage examples.

**New timestamp-based VT adjustment support:**

* Added `SetVtAsync` and `SetVtBatchAsync` overloads to `INpgmqClient` and `NpgmqClient` that accept a `DateTimeOffset` for direct timestamp-based VT adjustment, supporting pgmq 1.10.0+ [[1]](diffhunk://#diff-9ad7d8636d9f2f51785f41dee5d06f0ea36368c0a825656b300b7a164bfd2f95R336-R347) [[2]](diffhunk://#diff-9ad7d8636d9f2f51785f41dee5d06f0ea36368c0a825656b300b7a164bfd2f95R362-R375) [[3]](diffhunk://#diff-a64524d20b336165340c125c9d7419bc401f09381307c7100ad34a76e756d00aL838-R866) [[4]](diffhunk://#diff-a64524d20b336165340c125c9d7419bc401f09381307c7100ad34a76e756d00aL861-R921).
* Added new integration tests for `SetVtAsync` and `SetVtBatchAsync` using timestamps, gated on pgmq 1.10.0 or later [[1]](diffhunk://#diff-369dedd94d406b7ee7f31aa6273f051a288be041a948662b920ff1f47427e2f0R1311-R1339) [[2]](diffhunk://#diff-369dedd94d406b7ee7f31aa6273f051a288be041a948662b920ff1f47427e2f0R1376-R1415).

**Testing and CI improvements:**

* Updated GitHub Actions workflow to run tests against pgmq 1.10.0 in addition to other versions.

**Documentation improvements:**

* Expanded the README with clearer instructions on client creation, dependency injection usage, and links to example projects [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L18-R38) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R73-R78) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L84).

**Codebase cleanup:**

* Removed an unused `using Npgsql;` directive from `NpgmqClientStressTest.cs`.
* Fixed resource disposal in `NpgmqCommand` by overriding `Dispose(bool)` instead of `DisposeAsync` for more reliable connection cleanup.