### PR TITLE
Add topic routing support to NpgmqClient

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Contributions are welcome. Feel free to submit a pull request.
 If you're not sure about something, open an issue first to discuss it.
 
 To make sure your pull request goes smoothly, please follow these guidelines:
-1. Run the tests before submitting your pull request. If you're adding a new feature, add a test for it.
-2. Follow the existing code style as much as possible.
+1. [Run the tests](Npgmq.Test/README.md) before submitting your pull request. If you're adding a new feature, add a test for it.
+2. Follow the existing code style.
 3. Make sure your code is formatted with `dotnet format`. The GitHub Action will fail if dotnet format results in any changes.
 

--- a/Npgmq.Example.Console/Npgmq.Example.Console.csproj
+++ b/Npgmq.Example.Console/Npgmq.Example.Console.csproj
@@ -13,8 +13,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.2" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.2" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.5" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.5" />
     </ItemGroup>
 
 </Project>

--- a/Npgmq.Example.Console/Program.cs
+++ b/Npgmq.Example.Console/Program.cs
@@ -3,28 +3,27 @@ using Microsoft.Extensions.Configuration;
 using Npgmq;
 using Npgsql;
 
-const string defaultConnectionString = "Host=localhost;Username=postgres;Password=postgres;Database=npgmq_test;";
+await EnsureNpgmqInitializedAsync();
+await DemoNpgmqClientWithConnectionStringAsync();
+await DemoNpgmqClientWithDataSourceAsync();
+await DemoNpgmqClientWithConnectionAndTransactionAsync();
+await DemoNpgmqClientTopicRouting();
+return;
 
-var configuration = new ConfigurationBuilder()
-    .AddEnvironmentVariables()
-    .AddUserSecrets(Assembly.GetExecutingAssembly())
-    .Build();
-
-var connectionString = configuration.GetConnectionString("ExampleDB") ?? defaultConnectionString;
-
-// Test Npgmq with connection string
+async Task EnsureNpgmqInitializedAsync()
 {
-    Console.WriteLine("NpgmqClient using a connection string...");
-    var npgmq = new NpgmqClient(connectionString);
-
+    var npgmq = new NpgmqClient(GetConnectionString());
     await npgmq.InitAsync();
+}
+
+async Task DemoNpgmqClientWithConnectionStringAsync()
+{
+    Console.WriteLine("Demoing NpgmqClient using a connection string...");
+    var npgmq = new NpgmqClient(GetConnectionString());
+
     await npgmq.CreateQueueAsync("example_queue");
 
-    var msgId = await npgmq.SendAsync("example_queue", new MyMessageType
-    {
-        Foo = "Connection string test",
-        Bar = 1
-    });
+    var msgId = await npgmq.SendAsync("example_queue", new MyMessageType("Connection string test", 1));
     Console.WriteLine($"Sent message with id {msgId}");
 
     var msg = await npgmq.ReadAsync<MyMessageType>("example_queue");
@@ -36,21 +35,16 @@ var connectionString = configuration.GetConnectionString("ExampleDB") ?? default
     Console.WriteLine();
 }
 
-// Test Npgmq with data source
+async Task DemoNpgmqClientWithDataSourceAsync()
 {
-    Console.WriteLine("NpgmqClient using a data source...");
+    Console.WriteLine("Demoing NpgmqClient using a data source...");
 
-    await using var dataSource = NpgsqlDataSource.Create(connectionString);
+    await using var dataSource = NpgsqlDataSource.Create(GetConnectionString());
     var npgmq = new NpgmqClient(dataSource);
 
-    await npgmq.InitAsync();
     await npgmq.CreateQueueAsync("example_queue");
 
-    var msgId = await npgmq.SendAsync("example_queue", new MyMessageType
-    {
-        Foo = "Connection string test",
-        Bar = 1
-    });
+    var msgId = await npgmq.SendAsync("example_queue", new MyMessageType("Data source test", 2));
     Console.WriteLine($"Sent message with id {msgId}");
 
     var msg = await npgmq.ReadAsync<MyMessageType>("example_queue");
@@ -62,26 +56,18 @@ var connectionString = configuration.GetConnectionString("ExampleDB") ?? default
     Console.WriteLine();
 }
 
-// Test Npgmq with connection object and a transaction
+async Task DemoNpgmqClientWithConnectionAndTransactionAsync()
 {
-    Console.WriteLine("NpgmqClient using a connection object with a transaction...");
-    await using var connection = new NpgsqlConnection(connectionString);
+    Console.WriteLine("Demoing NpgmqClient using a connection object with a transaction...");
+    await using var connection = new NpgsqlConnection(GetConnectionString());
     await connection.OpenAsync();
     var npgmq = new NpgmqClient(connection);
 
     await using (var tx = await connection.BeginTransactionAsync())
     {
-        var msgId = await npgmq.SendAsync("example_queue", new MyMessageType
-        {
-            Foo = "Connection object test",
-            Bar = 2
-        });
+        var msgId = await npgmq.SendAsync("example_queue", new MyMessageType("Connection object with transaction test", 3));
         Console.WriteLine($"Sent message with id {msgId}");
-        msgId = await npgmq.SendAsync("example_queue", new MyMessageType
-        {
-            Foo = "Connection object test",
-            Bar = 3
-        });
+        msgId = await npgmq.SendAsync("example_queue", new MyMessageType("Connection object with transaction test", 4));
         Console.WriteLine($"Sent message with id {msgId}");
 
         await tx.CommitAsync();
@@ -102,8 +88,70 @@ var connectionString = configuration.GetConnectionString("ExampleDB") ?? default
     Console.WriteLine();
 }
 
-internal class MyMessageType
+async Task DemoNpgmqClientTopicRouting()
 {
-    public string Foo { get; set; } = null!;
-    public int Bar { get; set; }
+    Console.WriteLine("Demoing topic routing...");
+    var npgmq = new NpgmqClient(GetConnectionString());
+
+    if ((await npgmq.GetPgmqVersionAsync()) < new Version(1, 11))
+    {
+        Console.WriteLine("SKIPPED: Topic routing requires pgmq 1.11.0 or later");
+        return;
+    }
+
+    var queueNames = new[] { "all_logs", "error_logs", "api_errors" };
+    foreach (string queueName in queueNames)
+    {
+        await npgmq.CreateQueueAsync(queueName);
+    }
+
+    await npgmq.BindTopicAsync("logs.#", "all_logs");
+    await npgmq.BindTopicAsync("logs.*.error", "error_logs");
+    await npgmq.BindTopicAsync("logs.api.error", "api_errors");
+
+    var topicBindings = await npgmq.ListTopicBindingsAsync();
+    Console.WriteLine($"There are {topicBindings.Count} topic bindings");
+    foreach (var topicBinding in topicBindings)
+    {
+        Console.WriteLine($"Topic pattern '{topicBinding.Pattern}' is bound to queue '{topicBinding.QueueName}'");
+    }
+
+    await npgmq.SendTopicAsync("logs.api.error", new MyLogMessageRecord("API failed"));
+    await npgmq.SendTopicAsync("logs.db.error", new MyLogMessageRecord("DB connection failed"));
+    await npgmq.SendTopicAsync("logs.api.info", new MyLogMessageRecord("Request received"));
+
+    foreach (string queueName in queueNames)
+    {
+        var messages = await npgmq.ReadBatchAsync<MyLogMessageRecord>(queueName);
+        Console.WriteLine($"Queue {queueName} read {messages.Count} messages");
+        foreach (var m in messages)
+        {
+            Console.WriteLine($"Queue {queueName} read log record with text: {m.Message?.Text}");
+            await npgmq.ArchiveAsync(queueName, m.MsgId);
+        }
+    }
+
+    await npgmq.UnbindTopicAsync("logs.#", "all_logs");
+    await npgmq.UnbindTopicAsync("logs.*.error", "error_logs");
+    await npgmq.UnbindTopicAsync("logs.api.error", "api_errors");
+
+    topicBindings = await npgmq.ListTopicBindingsAsync();
+    Console.WriteLine($"There are {topicBindings.Count} topic bindings");
+
+    Console.WriteLine();
 }
+
+string GetConnectionString()
+{
+    const string defaultConnectionString = "Host=localhost;Username=postgres;Password=postgres;Database=npgmq_test;";
+
+    var configuration = new ConfigurationBuilder()
+        .AddEnvironmentVariables()
+        .AddUserSecrets(Assembly.GetExecutingAssembly())
+        .Build();
+
+    return configuration.GetConnectionString("ExampleDB") ?? defaultConnectionString;
+}
+
+internal record MyMessageType(string Foo, int Bar);
+internal record MyLogMessageRecord(string Text);

--- a/Npgmq.Example.Console/Program.cs
+++ b/Npgmq.Example.Console/Program.cs
@@ -7,7 +7,7 @@ await EnsureNpgmqInitializedAsync();
 await DemoNpgmqClientWithConnectionStringAsync();
 await DemoNpgmqClientWithDataSourceAsync();
 await DemoNpgmqClientWithConnectionAndTransactionAsync();
-await DemoNpgmqClientTopicRouting();
+await DemoNpgmqClientTopicRoutingAsync();
 return;
 
 async Task EnsureNpgmqInitializedAsync()
@@ -88,7 +88,7 @@ async Task DemoNpgmqClientWithConnectionAndTransactionAsync()
     Console.WriteLine();
 }
 
-async Task DemoNpgmqClientTopicRouting()
+async Task DemoNpgmqClientTopicRoutingAsync()
 {
     Console.WriteLine("Demoing topic routing...");
     var npgmq = new NpgmqClient(GetConnectionString());

--- a/Npgmq.Example.Console/README.md
+++ b/Npgmq.Example.Console/README.md
@@ -1,3 +1,3 @@
 # Npgmq.Example.Console
 
-Example console project for Npgmq.
+Example console project that demonstrates NpgmqClient.

--- a/Npgmq.Example.Web/Npgmq.Example.Web.csproj
+++ b/Npgmq.Example.Web/Npgmq.Example.Web.csproj
@@ -11,7 +11,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Npgsql" Version="10.0.1" />
+      <PackageReference Include="Npgsql" Version="10.0.2" />
     </ItemGroup>
 
 </Project>

--- a/Npgmq.Example.Web/README.md
+++ b/Npgmq.Example.Web/README.md
@@ -1,3 +1,3 @@
 # Npgmq.Example.Web
 
-Example web project for Npgmq.
+Example web project that demonstrates NpgmqClient.

--- a/Npgmq.Test/Npgmq.Test.csproj
+++ b/Npgmq.Test/Npgmq.Test.csproj
@@ -12,12 +12,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Dapper" Version="2.1.66" />
+        <PackageReference Include="Dapper" Version="2.1.72" />
         <PackageReference Include="DeepEqual" Version="5.1.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.2" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.2" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.5" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.5" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Npgmq.Test/NpgmqClientTest.Topic.cs
+++ b/Npgmq.Test/NpgmqClientTest.Topic.cs
@@ -1,0 +1,428 @@
+using System.Text.Json;
+using Dapper;
+using DeepEqual.Syntax;
+
+namespace Npgmq.Test;
+
+public partial class NpgmqClientTest
+{
+    [SkippableFact]
+    public async Task BindTopicAsync_should_be_idempotent_and_list_topic_bindings()
+    {
+        Skip.IfNot(await IsMinPgmqVersion("1.11.0"), "requires pgmq 1.11.0 or later.");
+
+        // Arrange
+        await _sut.CreateQueueAsync(_testQueueName);
+
+        // Act
+        await _sut.BindTopicAsync("orders.*", _testQueueName);
+        await _sut.BindTopicAsync("orders.*", _testQueueName);
+        await _sut.BindTopicAsync("orders.created", _testQueueName);
+
+        var allBindings = await _sut.ListTopicBindingsAsync();
+        var queueBindings = await _sut.ListTopicBindingsAsync(_testQueueName);
+
+        // Assert
+        Assert.Equal(2, queueBindings.Count);
+        Assert.Equal(2, allBindings.Count(x => x.QueueName == _testQueueName));
+
+        var bindingsByPattern = queueBindings.ToDictionary(x => x.Pattern);
+        Assert.Equal(["orders.*", "orders.created"], bindingsByPattern.Keys.Order().ToArray());
+
+        Assert.All(bindingsByPattern.Values, binding =>
+        {
+            Assert.Equal(_testQueueName, binding.QueueName);
+            Assert.NotEqual(default, binding.BoundAt);
+            Assert.False(string.IsNullOrWhiteSpace(binding.CompiledRegex));
+        });
+    }
+
+    [SkippableFact]
+    public async Task UnbindTopicAsync_should_remove_binding_and_return_false_when_it_does_not_exist()
+    {
+        Skip.IfNot(await IsMinPgmqVersion("1.11.0"), "requires pgmq 1.11.0 or later.");
+
+        // Arrange
+        await _sut.CreateQueueAsync(_testQueueName);
+        await _sut.BindTopicAsync("orders.#", _testQueueName);
+
+        // Act
+        var removed = await _sut.UnbindTopicAsync("orders.#", _testQueueName);
+        var removedAgain = await _sut.UnbindTopicAsync("orders.#", _testQueueName);
+        var remainingBindings = await _sut.ListTopicBindingsAsync(_testQueueName);
+
+        // Assert
+        Assert.True(removed);
+        Assert.False(removedAgain);
+        Assert.Empty(remainingBindings);
+    }
+
+    [SkippableFact]
+    public async Task SendTopicAsync_should_route_message_to_all_matching_queues_and_return_queue_count()
+    {
+        Skip.IfNot(await IsMinPgmqVersion("1.11.0"), "requires pgmq 1.11.0 or later.");
+
+        var secondaryQueueName = _testQueueName + "_secondary";
+
+        try
+        {
+            // Arrange
+            await _sut.CreateQueueAsync(_testQueueName);
+            await _sut.CreateQueueAsync(secondaryQueueName);
+            await _sut.BindTopicAsync("orders.#", _testQueueName);
+            await _sut.BindTopicAsync("orders.created", secondaryQueueName);
+
+            var message = new TestMessage
+            {
+                Foo = 123,
+                Bar = "created"
+            };
+
+            // Act
+            var result = await _sut.SendTopicAsync("orders.created", message);
+
+            var primaryQueueMessage = await _sut.ReadAsync<TestMessage>(_testQueueName);
+            var secondaryQueueMessage = await _sut.ReadAsync<TestMessage>(secondaryQueueName);
+
+            // Assert
+            Assert.Equal(2, result);
+
+            Assert.NotNull(primaryQueueMessage);
+            Assert.NotNull(secondaryQueueMessage);
+
+            primaryQueueMessage.Message.ShouldDeepEqual(message);
+            secondaryQueueMessage.Message.ShouldDeepEqual(message);
+
+            Assert.Null(primaryQueueMessage.Headers);
+            Assert.Null(secondaryQueueMessage.Headers);
+        }
+        finally
+        {
+            // Cleanup
+            try { await _sut.DropQueueAsync(secondaryQueueName); } catch { /* ignored */ }
+        }
+    }
+
+    [SkippableFact]
+    public async Task SendTopicAsync_should_return_zero_when_no_bindings_match()
+    {
+        Skip.IfNot(await IsMinPgmqVersion("1.11.0"), "requires pgmq 1.11.0 or later.");
+
+        // Arrange
+        await _sut.CreateQueueAsync(_testQueueName);
+        await _sut.BindTopicAsync("orders.#", _testQueueName);
+
+        // Act
+        var result = await _sut.SendTopicAsync("payments.failed", new TestMessage { Foo = 123 });
+
+        // Assert
+        Assert.Equal(0, result);
+        Assert.Equal(0, await _connection.ExecuteScalarAsync<long>($"SELECT count(*) FROM pgmq.q_{_testQueueName};"));
+    }
+
+    [SkippableFact]
+    public async Task SendTopicAsync_should_add_message_with_numeric_delay()
+    {
+        Skip.IfNot(await IsMinPgmqVersion("1.11.0"), "requires pgmq 1.11.0 or later.");
+
+        // Arrange
+        await _sut.CreateQueueAsync(_testQueueName);
+        await _sut.BindTopicAsync("notifications.email", _testQueueName);
+
+        var message = new TestMessage
+        {
+            Foo = 123,
+            Bar = "delayed"
+        };
+
+        // Act
+        var result = await _sut.SendTopicAsync("notifications.email", message, 60);
+
+        var actualRow = await _connection.QuerySingleAsync<(string Message, string Headers, DateTime Vt)>(
+            $"SELECT message AS Message, headers AS Headers, vt AS Vt FROM pgmq.q_{_testQueueName} LIMIT 1;");
+
+        // Assert
+        Assert.Equal(1, result);
+
+        JsonSerializer.Deserialize<TestMessage>(actualRow.Message).ShouldDeepEqual(message);
+        Assert.Null(actualRow.Headers);
+        Assert.True(actualRow.Vt.ToDateTimeOffset() > DateTimeOffset.UtcNow);
+    }
+
+    [SkippableFact]
+    public async Task SendTopicAsync_should_add_message_with_headers_and_numeric_delay()
+    {
+        Skip.IfNot(await IsMinPgmqVersion("1.11.0"), "requires pgmq 1.11.0 or later.");
+
+        // Arrange
+        await _sut.CreateQueueAsync(_testQueueName);
+        await _sut.BindTopicAsync("notifications.email", _testQueueName);
+
+        var headers = new Dictionary<string, object>
+        {
+            { "some-header", 456 },
+            { "another-header", "test" }
+        };
+        var message = new TestMessage
+        {
+            Foo = 123,
+            Bar = "delayed"
+        };
+
+        // Act
+        var result = await _sut.SendTopicAsync("notifications.email", message, headers, 60);
+
+        var actualRow = await _connection.QuerySingleAsync<(string Message, string Headers, DateTime Vt)>(
+            $"SELECT message AS Message, headers AS Headers, vt AS Vt FROM pgmq.q_{_testQueueName} LIMIT 1;");
+
+        // Assert
+        Assert.Equal(1, result);
+
+        JsonSerializer.Deserialize<TestMessage>(actualRow.Message).ShouldDeepEqual(message);
+        JsonSerializer.Deserialize<Dictionary<string, object>>(actualRow.Headers, DeserializationOptions)
+            .ShouldDeepEqual(headers);
+        Assert.True(actualRow.Vt.ToDateTimeOffset() > DateTimeOffset.UtcNow);
+    }
+
+    [SkippableFact]
+    public async Task SendBatchTopicAsync_should_route_messages_to_all_matching_queues_and_return_results_for_each_queue()
+    {
+        Skip.IfNot(await IsMinPgmqVersion("1.11.0"), "requires pgmq 1.11.0 or later.");
+
+        var secondaryQueueName = _testQueueName + "_secondary";
+
+        try
+        {
+            // Arrange
+            await _sut.CreateQueueAsync(_testQueueName);
+            await _sut.CreateQueueAsync(secondaryQueueName);
+            await _sut.BindTopicAsync("orders.#", _testQueueName);
+            await _sut.BindTopicAsync("orders.created", secondaryQueueName);
+
+            var messages = new List<TestMessage>
+            {
+                new() { Foo = 1 },
+                new() { Foo = 2 }
+            };
+
+            // Act
+            var results = await _sut.SendBatchTopicAsync("orders.created", messages);
+
+            var primaryQueueMessages = await _sut.ReadBatchAsync<TestMessage>(_testQueueName);
+            var secondaryQueueMessages = await _sut.ReadBatchAsync<TestMessage>(secondaryQueueName);
+
+            // Assert
+            Assert.Equal(4, results.Count);
+            Assert.Equal(2, results.Count(x => x.QueueName == _testQueueName));
+            Assert.Equal(2, results.Count(x => x.QueueName == secondaryQueueName));
+
+            primaryQueueMessages.Select(x => x.Message).OrderBy(x => x!.Foo)
+                .ShouldDeepEqual(messages.OrderBy(x => x.Foo));
+            secondaryQueueMessages.Select(x => x.Message).OrderBy(x => x!.Foo)
+                .ShouldDeepEqual(messages.OrderBy(x => x.Foo));
+
+            primaryQueueMessages.Select(x => x.MsgId).OrderBy(x => x)
+                .ShouldDeepEqual(results.Where(x => x.QueueName == _testQueueName).Select(x => x.MsgId).OrderBy(x => x));
+            secondaryQueueMessages.Select(x => x.MsgId).OrderBy(x => x)
+                .ShouldDeepEqual(results.Where(x => x.QueueName == secondaryQueueName).Select(x => x.MsgId).OrderBy(x => x));
+        }
+        finally
+        {
+            // Cleanup
+            try { await _sut.DropQueueAsync(secondaryQueueName); } catch { /* ignored */ }
+        }
+    }
+    [SkippableFact]
+    public async Task SendBatchTopicAsync_should_add_messages_with_headers()
+    {
+        Skip.IfNot(await IsMinPgmqVersion("1.11.0"), "requires pgmq 1.11.0 or later.");
+
+        // Arrange
+        await _sut.CreateQueueAsync(_testQueueName);
+        await _sut.BindTopicAsync("notifications.#", _testQueueName);
+
+        var messages = new List<TestMessage>
+        {
+            new() { Foo = 1, Bar = "a" },
+            new() { Foo = 2, Bar = "b" }
+        };
+        var headers = new List<Dictionary<string, object>>
+        {
+            new() { { "header1", "aaa" } },
+            new() { { "header1", "bbb" }, { "header2", 987 } }
+        };
+
+        // Act
+        var results = await _sut.SendBatchTopicAsync("notifications.email", messages, headers);
+
+        var actualRows = (await _connection.QueryAsync<(long MsgId, string Message, string Headers, DateTime Vt)>(
+            $"SELECT msg_id AS MsgId, message AS Message, headers AS Headers, vt AS Vt FROM pgmq.q_{_testQueueName} ORDER BY msg_id;")).ToList();
+
+        // Assert
+        Assert.Equal(2, results.Count);
+        Assert.Equal(2, actualRows.Count);
+
+        Assert.Equal(results.Select(x => x.MsgId).OrderBy(x => x), actualRows.Select(x => x.MsgId).OrderBy(x => x));
+
+        for (var i = 0; i < actualRows.Count; i++)
+        {
+            JsonSerializer.Deserialize<TestMessage>(actualRows[i].Message).ShouldDeepEqual(messages[i]);
+            JsonSerializer.Deserialize<Dictionary<string, object>>(actualRows[i].Headers, DeserializationOptions)
+                .ShouldDeepEqual(headers[i]);
+        }
+    }
+
+    [SkippableFact]
+    public async Task SendBatchTopicAsync_should_add_messages_with_timestamp_delay()
+    {
+        Skip.IfNot(await IsMinPgmqVersion("1.11.0"), "requires pgmq 1.11.0 or later.");
+
+        // Arrange
+        await _sut.CreateQueueAsync(_testQueueName);
+        await _sut.BindTopicAsync("notifications.#", _testQueueName);
+
+        var messages = new List<TestMessage>
+        {
+            new() { Foo = 1, Bar = "a" },
+            new() { Foo = 2, Bar = "b" }
+        };
+        var delay = DateTimeOffset.UtcNow.AddSeconds(60).TruncateToMicroseconds();
+
+        // Act
+        var results = await _sut.SendBatchTopicAsync("notifications.email", messages, delay);
+
+        var actualRows = (await _connection.QueryAsync<(long MsgId, string Message, string Headers, DateTime Vt)>(
+            $"SELECT msg_id AS MsgId, message AS Message, headers AS Headers, vt AS Vt FROM pgmq.q_{_testQueueName} ORDER BY msg_id;")).ToList();
+
+        // Assert
+        Assert.Equal(2, results.Count);
+        Assert.Equal(2, actualRows.Count);
+
+        Assert.Equal(results.Select(x => x.MsgId).OrderBy(x => x), actualRows.Select(x => x.MsgId).OrderBy(x => x));
+        Assert.True(actualRows.All(x => x.Vt.ToDateTimeOffset().TruncateToMicroseconds() == delay));
+
+        for (var i = 0; i < actualRows.Count; i++)
+        {
+            JsonSerializer.Deserialize<TestMessage>(actualRows[i].Message).ShouldDeepEqual(messages[i]);
+            Assert.Null(actualRows[i].Headers);
+        }
+    }
+
+    [SkippableFact]
+    public async Task SendBatchTopicAsync_should_add_messages_with_numeric_delay()
+    {
+        Skip.IfNot(await IsMinPgmqVersion("1.11.0"), "requires pgmq 1.11.0 or later.");
+
+        // Arrange
+        await _sut.CreateQueueAsync(_testQueueName);
+        await _sut.BindTopicAsync("notifications.#", _testQueueName);
+
+        var messages = new List<TestMessage>
+        {
+            new() { Foo = 1, Bar = "a" },
+            new() { Foo = 2, Bar = "b" }
+        };
+
+        // Act
+        var results = await _sut.SendBatchTopicAsync("notifications.email", messages, 60);
+
+        var actualRows = (await _connection.QueryAsync<(long MsgId, string Message, string Headers, DateTime Vt)>(
+            $"SELECT msg_id AS MsgId, message AS Message, headers AS Headers, vt AS Vt FROM pgmq.q_{_testQueueName} ORDER BY msg_id;")).ToList();
+
+        // Assert
+        Assert.Equal(2, results.Count);
+        Assert.Equal(2, actualRows.Count);
+
+        Assert.Equal(results.Select(x => x.MsgId).OrderBy(x => x), actualRows.Select(x => x.MsgId).OrderBy(x => x));
+        Assert.True(actualRows.All(x => x.Vt.ToDateTimeOffset() > DateTimeOffset.UtcNow));
+
+        for (var i = 0; i < actualRows.Count; i++)
+        {
+            JsonSerializer.Deserialize<TestMessage>(actualRows[i].Message).ShouldDeepEqual(messages[i]);
+            Assert.Null(actualRows[i].Headers);
+        }
+    }
+
+    [SkippableFact]
+    public async Task SendBatchTopicAsync_should_add_messages_with_headers_and_timestamp_delay()
+    {
+        Skip.IfNot(await IsMinPgmqVersion("1.11.0"), "requires pgmq 1.11.0 or later.");
+
+        // Arrange
+        await _sut.CreateQueueAsync(_testQueueName);
+        await _sut.BindTopicAsync("notifications.#", _testQueueName);
+
+        var messages = new List<TestMessage>
+        {
+            new() { Foo = 1, Bar = "a" },
+            new() { Foo = 2, Bar = "b" }
+        };
+        var headers = new List<Dictionary<string, object>>
+        {
+            new() { { "header1", "aaa" } },
+            new() { { "header1", "bbb" }, { "header2", 987 } }
+        };
+        var delay = DateTimeOffset.UtcNow.AddSeconds(60).TruncateToMicroseconds();
+
+        // Act
+        var results = await _sut.SendBatchTopicAsync("notifications.email", messages, headers, delay);
+
+        var actualRows = (await _connection.QueryAsync<(long MsgId, string Message, string Headers, DateTime Vt)>(
+            $"SELECT msg_id AS MsgId, message AS Message, headers AS Headers, vt AS Vt FROM pgmq.q_{_testQueueName} ORDER BY msg_id;")).ToList();
+
+        // Assert
+        Assert.Equal(2, results.Count);
+        Assert.Equal(2, actualRows.Count);
+
+        Assert.Equal(results.Select(x => x.MsgId).OrderBy(x => x), actualRows.Select(x => x.MsgId).OrderBy(x => x));
+        Assert.True(actualRows.All(x => x.Vt.ToDateTimeOffset().TruncateToMicroseconds() == delay));
+
+        for (var i = 0; i < actualRows.Count; i++)
+        {
+            JsonSerializer.Deserialize<TestMessage>(actualRows[i].Message).ShouldDeepEqual(messages[i]);
+            JsonSerializer.Deserialize<Dictionary<string, object>>(actualRows[i].Headers, DeserializationOptions)
+                .ShouldDeepEqual(headers[i]);
+        }
+    }
+
+    [SkippableFact]
+    public async Task SendBatchTopicAsync_should_add_messages_with_headers_and_numeric_delay()
+    {
+        Skip.IfNot(await IsMinPgmqVersion("1.11.0"), "requires pgmq 1.11.0 or later.");
+
+        // Arrange
+        await _sut.CreateQueueAsync(_testQueueName);
+        await _sut.BindTopicAsync("notifications.#", _testQueueName);
+
+        var messages = new List<TestMessage>
+        {
+            new() { Foo = 1, Bar = "a" },
+            new() { Foo = 2, Bar = "b" }
+        };
+        var headers = new List<Dictionary<string, object>>
+        {
+            new() { { "header1", "aaa" } },
+            new() { { "header1", "bbb" }, { "header2", 987 } }
+        };
+
+        // Act
+        var results = await _sut.SendBatchTopicAsync("notifications.email", messages, headers, 60);
+
+        var actualRows = (await _connection.QueryAsync<(long MsgId, string Message, string Headers, DateTime Vt)>(
+            $"SELECT msg_id AS MsgId, message AS Message, headers AS Headers, vt AS Vt FROM pgmq.q_{_testQueueName} ORDER BY msg_id;")).ToList();
+
+        // Assert
+        Assert.Equal(2, results.Count);
+        Assert.Equal(2, actualRows.Count);
+
+        Assert.Equal(results.Select(x => x.MsgId).OrderBy(x => x), actualRows.Select(x => x.MsgId).OrderBy(x => x));
+        Assert.True(actualRows.All(x => x.Vt.ToDateTimeOffset() > DateTimeOffset.UtcNow));
+
+        for (var i = 0; i < actualRows.Count; i++)
+        {
+            JsonSerializer.Deserialize<TestMessage>(actualRows[i].Message).ShouldDeepEqual(messages[i]);
+            JsonSerializer.Deserialize<Dictionary<string, object>>(actualRows[i].Headers, DeserializationOptions)
+                .ShouldDeepEqual(headers[i]);
+        }
+    }
+}

--- a/Npgmq.Test/NpgmqClientTest.cs
+++ b/Npgmq.Test/NpgmqClientTest.cs
@@ -56,15 +56,24 @@ public sealed partial class NpgmqClientTest : IClassFixture<PostgresFixture>, IA
     }
 
     [Fact]
-    public async Task NpgmqClient_should_throw_exception_when_provided_connection_is_null()
+    public void NpgmqClient_should_throw_exception_when_provided_connection_is_null()
     {
-        // Arrange
-        var sut = new NpgmqClient((NpgsqlConnection)null!);
-        var ex = await Assert.ThrowsAsync<NpgmqException>(async () => await sut.CreateQueueAsync(_testQueueName));
-        Assert.Equal($"Failed to create queue {_testQueueName}.", ex.Message);
-        Assert.NotNull(ex.InnerException);
-        Assert.IsType<NpgmqException>(ex.InnerException);
-        Assert.Equal("No valid connection configuration provided.", ex.InnerException.Message);
+        var ex = Assert.Throws<ArgumentNullException>(() => new NpgmqClient((NpgsqlConnection)null!));
+        Assert.Equal("connection", ex.ParamName);
+    }
+
+    [Fact]
+    public void NpgmqClient_should_throw_exception_when_provided_data_source_is_null()
+    {
+        var ex = Assert.Throws<ArgumentNullException>(() => new NpgmqClient((NpgsqlDataSource)null!));
+        Assert.Equal("dataSource", ex.ParamName);
+    }
+    
+    [Fact]
+    public void NpgmqClient_should_throw_exception_when_provided_connection_string_is_null()
+    {
+        var ex = Assert.Throws<ArgumentNullException>(() => new NpgmqClient((string)null!));
+        Assert.Equal("connectionString", ex.ParamName);
     }
 
     [Fact]

--- a/Npgmq.Test/NpgmqClientTest.cs
+++ b/Npgmq.Test/NpgmqClientTest.cs
@@ -8,7 +8,7 @@ using Npgsql;
 namespace Npgmq.Test;
 
 [Collection("Npgmq")]
-public sealed class NpgmqClientTest : IClassFixture<PostgresFixture>, IAsyncLifetime
+public sealed partial class NpgmqClientTest : IClassFixture<PostgresFixture>, IAsyncLifetime
 {
     private readonly PostgresFixture _postgresFixture;
     private readonly NpgsqlConnection _connection;
@@ -53,6 +53,18 @@ public sealed class NpgmqClientTest : IClassFixture<PostgresFixture>, IAsyncLife
     {
         var version = await _connection.ExecuteScalarAsync<string>("select extversion from pg_extension where extname = 'pgmq';");
         return version is not null && new Version(version) >= new Version(minVersion);
+    }
+
+    [Fact]
+    public async Task NpgmqClient_should_throw_exception_when_provided_connection_is_null()
+    {
+        // Arrange
+        var sut = new NpgmqClient((NpgsqlConnection)null!);
+        var ex = await Assert.ThrowsAsync<NpgmqException>(async () => await sut.CreateQueueAsync(_testQueueName));
+        Assert.Equal($"Failed to create queue {_testQueueName}.", ex.Message);
+        Assert.NotNull(ex.InnerException);
+        Assert.IsType<NpgmqException>(ex.InnerException);
+        Assert.Equal("No valid connection configuration provided.", ex.InnerException.Message);
     }
 
     [Fact]

--- a/Npgmq.Test/NpgmqClientTest.cs
+++ b/Npgmq.Test/NpgmqClientTest.cs
@@ -68,7 +68,7 @@ public sealed partial class NpgmqClientTest : IClassFixture<PostgresFixture>, IA
         var ex = Assert.Throws<ArgumentNullException>(() => new NpgmqClient((NpgsqlDataSource)null!));
         Assert.Equal("dataSource", ex.ParamName);
     }
-    
+
     [Fact]
     public void NpgmqClient_should_throw_exception_when_provided_connection_string_is_null()
     {

--- a/Npgmq/INpgmqClient.Topic.cs
+++ b/Npgmq/INpgmqClient.Topic.cs
@@ -113,7 +113,7 @@ public partial interface INpgmqClient
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <typeparam name="T">The message type.</typeparam>
     /// <returns>List of messages sent.</returns>
-    Task<List<NpgmqSendTopicResult>> SendBatchTopicAsync<T>(string routingKey, IEnumerable<T> messages, IReadOnlyList<IReadOnlyDictionary<string, object>> headers, CancellationToken cancellationToken = default) where T : class;
+    Task<List<NpgmqSendTopicResult>> SendBatchTopicAsync<T>(string routingKey, IReadOnlyList<T> messages, IReadOnlyList<IReadOnlyDictionary<string, object>> headers, CancellationToken cancellationToken = default) where T : class;
 
     /// <summary>
     /// Sends messages to the topic with the specified routing key.
@@ -156,7 +156,7 @@ public partial interface INpgmqClient
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <typeparam name="T">The message type.</typeparam>
     /// <returns>List of messages sent.</returns>
-    Task<List<NpgmqSendTopicResult>> SendBatchTopicAsync<T>(string routingKey, IEnumerable<T> messages, IReadOnlyList<IReadOnlyDictionary<string, object>> headers, int delay, CancellationToken cancellationToken = default) where T : class;
+    Task<List<NpgmqSendTopicResult>> SendBatchTopicAsync<T>(string routingKey, IReadOnlyList<T> messages, IReadOnlyList<IReadOnlyDictionary<string, object>> headers, int delay, CancellationToken cancellationToken = default) where T : class;
 
     /// <summary>
     /// Sends messages to the topic with the specified routing key.
@@ -171,5 +171,5 @@ public partial interface INpgmqClient
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <typeparam name="T">The message type.</typeparam>
     /// <returns>List of messages sent.</returns>
-    Task<List<NpgmqSendTopicResult>> SendBatchTopicAsync<T>(string routingKey, IEnumerable<T> messages, IReadOnlyList<IReadOnlyDictionary<string, object>> headers, DateTimeOffset delay, CancellationToken cancellationToken = default) where T : class;
+    Task<List<NpgmqSendTopicResult>> SendBatchTopicAsync<T>(string routingKey, IReadOnlyList<T> messages, IReadOnlyList<IReadOnlyDictionary<string, object>> headers, DateTimeOffset delay, CancellationToken cancellationToken = default) where T : class;
 }

--- a/Npgmq/INpgmqClient.Topic.cs
+++ b/Npgmq/INpgmqClient.Topic.cs
@@ -1,0 +1,175 @@
+namespace Npgmq;
+
+public partial interface INpgmqClient
+{
+    /// <summary>
+    /// Binds a topic pattern to a queue. Messages sent to the topic with a routing key that matches the pattern will be delivered to the queue.
+    /// </summary>
+    /// <remarks>
+    /// Requires pgmq 1.11.0 or later.
+    /// </remarks>
+    /// <param name="pattern">The topic pattern to bind.</param>
+    /// <param name="queueName">The queue name.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    Task BindTopicAsync(string pattern, string queueName, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Unbinds a topic pattern from a queue.
+    /// </summary>
+    /// <remarks>
+    /// Requires pgmq 1.11.0 or later.
+    /// </remarks>
+    /// <param name="pattern">The topic pattern to unbind.</param>
+    /// <param name="queueName">The queue name.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>True if the binding was successfully removed, false if the binding did not exist.</returns>
+    Task<bool> UnbindTopicAsync(string pattern, string queueName, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Lists all topic bindings.
+    /// </summary>
+    /// <remarks>
+    /// Requires pgmq 1.11.0 or later.
+    /// </remarks>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>List of topic bindings.</returns>
+    Task<List<NpgmqTopicBinding>> ListTopicBindingsAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Lists all topic bindings for a specified queue.
+    /// </summary>
+    /// <remarks>
+    /// Requires pgmq 1.11.0 or later.
+    /// </remarks>
+    /// <param name="queueName">The queue name.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>List of topic bindings.</returns>
+    Task<List<NpgmqTopicBinding>> ListTopicBindingsAsync(string queueName, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Sends a message to the topic with the specified routing key.
+    /// </summary>
+    /// <remarks>
+    /// Requires pgmq 1.11.0 or later.
+    /// </remarks>
+    /// <param name="routingKey">The routing key.</param>
+    /// <param name="message">The message to send.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <typeparam name="T">The message type.</typeparam>
+    /// <returns>Number of messages sent.</returns>
+    Task<int> SendTopicAsync<T>(string routingKey, T message, CancellationToken cancellationToken = default) where T : class;
+
+    /// <summary>
+    /// Sends a message to the topic with the specified routing key.
+    /// </summary>
+    /// <remarks>
+    /// Requires pgmq 1.11.0 or later.
+    /// </remarks>
+    /// <param name="routingKey">The routing key.</param>
+    /// <param name="message">The message to send.</param>
+    /// <param name="delay">Number of seconds until the message becomes visible.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <typeparam name="T">The message type.</typeparam>
+    /// <returns>Number of messages sent.</returns>
+    Task<int> SendTopicAsync<T>(string routingKey, T message, int delay, CancellationToken cancellationToken = default) where T : class;
+
+    /// <summary>
+    /// Sends a message to the topic with the specified routing key.
+    /// </summary>
+    /// <remarks>
+    /// Requires pgmq 1.11.0 or later.
+    /// </remarks>
+    /// <param name="routingKey">The routing key.</param>
+    /// <param name="message">The message to send.</param>
+    /// <param name="headers">The message headers.</param>
+    /// <param name="delay">Number of seconds until the message becomes visible.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <typeparam name="T">The message type.</typeparam>
+    /// <returns>Number of messages sent.</returns>
+    Task<int> SendTopicAsync<T>(string routingKey, T message, IReadOnlyDictionary<string, object> headers, int delay, CancellationToken cancellationToken = default) where T : class;
+
+    /// <summary>
+    /// Sends messages to the topic with the specified routing key.
+    /// </summary>
+    /// <remarks>
+    /// Requires pgmq 1.11.0 or later.
+    /// </remarks>
+    /// <param name="routingKey">The routing key.</param>
+    /// <param name="messages">The messages to send.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <typeparam name="T">The message type.</typeparam>
+    /// <returns>List of messages sent.</returns>
+    Task<List<NpgmqSendTopicResult>> SendBatchTopicAsync<T>(string routingKey, IEnumerable<T> messages, CancellationToken cancellationToken = default) where T : class;
+
+    /// <summary>
+    /// Sends messages to the topic with the specified routing key.
+    /// </summary>
+    /// <remarks>
+    /// Requires pgmq 1.11.0 or later.
+    /// </remarks>
+    /// <param name="routingKey">The routing key.</param>
+    /// <param name="messages">The messages to send.</param>
+    /// <param name="headers">The message headers.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <typeparam name="T">The message type.</typeparam>
+    /// <returns>List of messages sent.</returns>
+    Task<List<NpgmqSendTopicResult>> SendBatchTopicAsync<T>(string routingKey, IEnumerable<T> messages, IReadOnlyList<IReadOnlyDictionary<string, object>> headers, CancellationToken cancellationToken = default) where T : class;
+
+    /// <summary>
+    /// Sends messages to the topic with the specified routing key.
+    /// </summary>
+    /// <remarks>
+    /// Requires pgmq 1.11.0 or later.
+    /// </remarks>
+    /// <param name="routingKey">The routing key.</param>
+    /// <param name="messages">The messages to send.</param>
+    /// <param name="delay">Number of seconds until the message becomes visible.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <typeparam name="T">The message type.</typeparam>
+    /// <returns>List of messages sent.</returns>
+    Task<List<NpgmqSendTopicResult>> SendBatchTopicAsync<T>(string routingKey, IEnumerable<T> messages, int delay, CancellationToken cancellationToken = default) where T : class;
+
+    /// <summary>
+    /// Sends messages to the topic with the specified routing key.
+    /// </summary>
+    /// <remarks>
+    /// Requires pgmq 1.11.0 or later.
+    /// </remarks>
+    /// <param name="routingKey">The routing key.</param>
+    /// <param name="messages">The messages to send.</param>
+    /// <param name="delay">Time at which the message becomes visible.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <typeparam name="T">The message type.</typeparam>
+    /// <returns>List of messages sent.</returns>
+    Task<List<NpgmqSendTopicResult>> SendBatchTopicAsync<T>(string routingKey, IEnumerable<T> messages, DateTimeOffset delay, CancellationToken cancellationToken = default) where T : class;
+
+    /// <summary>
+    /// Sends messages to the topic with the specified routing key.
+    /// </summary>
+    /// <remarks>
+    /// Requires pgmq 1.11.0 or later.
+    /// </remarks>
+    /// <param name="routingKey">The routing key.</param>
+    /// <param name="messages">The messages to send.</param>
+    /// <param name="headers">The message headers.</param>
+    /// <param name="delay">Number of seconds until the message becomes visible.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <typeparam name="T">The message type.</typeparam>
+    /// <returns>List of messages sent.</returns>
+    Task<List<NpgmqSendTopicResult>> SendBatchTopicAsync<T>(string routingKey, IEnumerable<T> messages, IReadOnlyList<IReadOnlyDictionary<string, object>> headers, int delay, CancellationToken cancellationToken = default) where T : class;
+
+    /// <summary>
+    /// Sends messages to the topic with the specified routing key.
+    /// </summary>
+    /// <remarks>
+    /// Requires pgmq 1.11.0 or later.
+    /// </remarks>
+    /// <param name="routingKey">The routing key.</param>
+    /// <param name="messages">The messages to send.</param>
+    /// <param name="headers">The message headers.</param>
+    /// <param name="delay">Time at which the message becomes visible.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <typeparam name="T">The message type.</typeparam>
+    /// <returns>List of messages sent.</returns>
+    Task<List<NpgmqSendTopicResult>> SendBatchTopicAsync<T>(string routingKey, IEnumerable<T> messages, IReadOnlyList<IReadOnlyDictionary<string, object>> headers, DateTimeOffset delay, CancellationToken cancellationToken = default) where T : class;
+}

--- a/Npgmq/INpgmqClient.cs
+++ b/Npgmq/INpgmqClient.cs
@@ -356,8 +356,7 @@ public partial interface INpgmqClient
     /// <param name="vtOffset">The number of seconds to be added to the current Vt.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>List of IDs that were updated.</returns>
-    Task<List<long>> SetVtBatchAsync(string queueName, IEnumerable<long> msgIds, int vtOffset,
-        CancellationToken cancellationToken = default);
+    Task<List<long>> SetVtBatchAsync(string queueName, IEnumerable<long> msgIds, int vtOffset, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Adjust the Vt of multiple existing messages.
@@ -370,8 +369,7 @@ public partial interface INpgmqClient
     /// <param name="vt">The new timestamp at which the messages become visible.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>List of IDs that were updated.</returns>
-    Task<List<long>> SetVtBatchAsync(string queueName, IEnumerable<long> msgIds, DateTimeOffset vt,
-        CancellationToken cancellationToken = default);
+    Task<List<long>> SetVtBatchAsync(string queueName, IEnumerable<long> msgIds, DateTimeOffset vt, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get metrics for all queues.

--- a/Npgmq/INpgmqClient.cs
+++ b/Npgmq/INpgmqClient.cs
@@ -3,7 +3,7 @@ namespace Npgmq;
 /// <summary>
 /// PGMQ client.
 /// </summary>
-public interface INpgmqClient
+public partial interface INpgmqClient
 {
     /// <summary>
     /// Default visibility timeout in seconds.

--- a/Npgmq/Npgmq.csproj
+++ b/Npgmq/Npgmq.csproj
@@ -19,8 +19,8 @@
 
     <ItemGroup>
       <PackageReference Include="JOS.SystemTextJson.DictionaryStringObject.JsonConverter" Version="3.0.0" />
-      <PackageReference Include="Npgsql" Version="10.0.1" />
-      <PackageReference Include="Npgsql.DependencyInjection" Version="10.0.1" />
+      <PackageReference Include="Npgsql" Version="10.0.2" />
+      <PackageReference Include="Npgsql.DependencyInjection" Version="10.0.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Npgmq/NpgmqClient.Topic.cs
+++ b/Npgmq/NpgmqClient.Topic.cs
@@ -1,0 +1,314 @@
+using System.Data.Common;
+using NpgsqlTypes;
+
+namespace Npgmq;
+
+public partial class NpgmqClient
+{
+    public async Task BindTopicAsync(string pattern, string queueName, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var cmd = await _commandFactory.CreateAsync("SELECT pgmq.bind_topic(@pattern, @queue_name);", cancellationToken).ConfigureAwait(false);
+            await using (cmd.ConfigureAwait(false))
+            {
+                cmd.Parameters.AddWithValue("@pattern", pattern);
+                cmd.Parameters.AddWithValue("@queue_name", queueName);
+                await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            throw new NpgmqException($"Failed to bind topic to queue {queueName}.", ex);
+        }
+    }
+
+    public async Task<bool> UnbindTopicAsync(string pattern, string queueName, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var cmd = await _commandFactory.CreateAsync("SELECT pgmq.unbind_topic(@pattern, @queue_name);", cancellationToken).ConfigureAwait(false);
+            await using (cmd.ConfigureAwait(false))
+            {
+                cmd.Parameters.AddWithValue("@pattern", pattern);
+                cmd.Parameters.AddWithValue("@queue_name", queueName);
+                var result = await cmd.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+                return result is not null && Convert.ToBoolean(result);
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            throw new NpgmqException($"Failed to unbind topic from queue {queueName}.", ex);
+        }
+    }
+
+    public async Task<List<NpgmqTopicBinding>> ListTopicBindingsAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var cmd = await _commandFactory.CreateAsync("SELECT pattern, queue_name, bound_at, compiled_regex FROM pgmq.list_topic_bindings();", cancellationToken).ConfigureAwait(false);
+            await using (cmd.ConfigureAwait(false))
+            {
+                var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+                await using (reader.ConfigureAwait(false))
+                {
+                    return await ReadTopicBindingsAsync(reader, cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            throw new NpgmqException("Failed to list topic bindings.", ex);
+        }
+    }
+
+    public async Task<List<NpgmqTopicBinding>> ListTopicBindingsAsync(string queueName, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var cmd = await _commandFactory.CreateAsync("SELECT pattern, queue_name, bound_at, compiled_regex FROM pgmq.list_topic_bindings(@queue_name);", cancellationToken).ConfigureAwait(false);
+            await using (cmd.ConfigureAwait(false))
+            {
+                cmd.Parameters.AddWithValue("@queue_name", queueName);
+                var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+                await using (reader.ConfigureAwait(false))
+                {
+                    return await ReadTopicBindingsAsync(reader, cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            throw new NpgmqException($"Failed to list topic bindings for queue {queueName}.", ex);
+        }
+    }
+
+    public async Task<int> SendTopicAsync<T>(string routingKey, T message, CancellationToken cancellationToken = default) where T : class
+    {
+        try
+        {
+            var cmd = await _commandFactory.CreateAsync("SELECT * FROM pgmq.send_topic(@routing_key, @msg);", cancellationToken).ConfigureAwait(false);
+            await using (cmd.ConfigureAwait(false))
+            {
+                cmd.Parameters.AddWithValue("@routing_key", routingKey);
+                cmd.Parameters.AddWithValue("@msg", NpgsqlDbType.Jsonb, SerializeMessage(message));
+                var result = await cmd.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+                return Convert.ToInt32(result);
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            throw new NpgmqException("Failed to send message to topic.", ex);
+        }
+    }
+
+    public async Task<int> SendTopicAsync<T>(string routingKey, T message, int delay, CancellationToken cancellationToken = default) where T : class
+    {
+        try
+        {
+            var cmd = await _commandFactory.CreateAsync("SELECT * FROM pgmq.send_topic(@routing_key, @msg, @delay);", cancellationToken).ConfigureAwait(false);
+            await using (cmd.ConfigureAwait(false))
+            {
+                cmd.Parameters.AddWithValue("@routing_key", routingKey);
+                cmd.Parameters.AddWithValue("@msg", NpgsqlDbType.Jsonb, SerializeMessage(message));
+                cmd.Parameters.AddWithValue("@delay", delay);
+                var result = await cmd.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+                return Convert.ToInt32(result);
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            throw new NpgmqException("Failed to send message to topic.", ex);
+        }
+    }
+
+    public async Task<int> SendTopicAsync<T>(string routingKey, T message, IReadOnlyDictionary<string, object> headers, int delay, CancellationToken cancellationToken = default) where T : class
+    {
+        try
+        {
+            var cmd = await _commandFactory.CreateAsync("SELECT * FROM pgmq.send_topic(@routing_key, @msg, @headers, @delay);", cancellationToken).ConfigureAwait(false);
+            await using (cmd.ConfigureAwait(false))
+            {
+                cmd.Parameters.AddWithValue("@routing_key", routingKey);
+                cmd.Parameters.AddWithValue("@msg", NpgsqlDbType.Jsonb, SerializeMessage(message));
+                cmd.Parameters.AddWithValue("@headers", NpgsqlDbType.Jsonb, SerializeHeaders(headers));
+                cmd.Parameters.AddWithValue("@delay", delay);
+                var result = await cmd.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+                return Convert.ToInt32(result);
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            throw new NpgmqException("Failed to send message to topic.", ex);
+        }
+    }
+
+    public async Task<List<NpgmqSendTopicResult>> SendBatchTopicAsync<T>(string routingKey, IEnumerable<T> messages, CancellationToken cancellationToken = default) where T : class
+    {
+        try
+        {
+            var cmd = await _commandFactory.CreateAsync("SELECT queue_name, msg_id FROM pgmq.send_batch_topic(@routing_key, @msgs);", cancellationToken).ConfigureAwait(false);
+            await using (cmd.ConfigureAwait(false))
+            {
+                cmd.Parameters.AddWithValue("@routing_key", routingKey);
+                cmd.Parameters.AddWithValue("@msgs", NpgsqlDbType.Array | NpgsqlDbType.Jsonb, messages.Select(SerializeMessage).ToArray());
+                var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+                await using (reader.ConfigureAwait(false))
+                {
+                    return await ReadSendTopicResponsesAsync(reader, cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            throw new NpgmqException("Failed to send messages to topic.", ex);
+        }
+    }
+
+    public async Task<List<NpgmqSendTopicResult>> SendBatchTopicAsync<T>(string routingKey, IEnumerable<T> messages, IReadOnlyList<IReadOnlyDictionary<string, object>> headers, CancellationToken cancellationToken = default) where T : class
+    {
+        try
+        {
+            var cmd = await _commandFactory.CreateAsync("SELECT queue_name, msg_id FROM pgmq.send_batch_topic(@routing_key, @msgs, @headers);", cancellationToken).ConfigureAwait(false);
+            await using (cmd.ConfigureAwait(false))
+            {
+                cmd.Parameters.AddWithValue("@routing_key", routingKey);
+                cmd.Parameters.AddWithValue("@msgs", NpgsqlDbType.Array | NpgsqlDbType.Jsonb, messages.Select(SerializeMessage).ToArray());
+                cmd.Parameters.AddWithValue("@headers", NpgsqlDbType.Array | NpgsqlDbType.Jsonb, headers.Select(SerializeHeaders).ToArray());
+                var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+                await using (reader.ConfigureAwait(false))
+                {
+                    return await ReadSendTopicResponsesAsync(reader, cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            throw new NpgmqException("Failed to send messages to topic.", ex);
+        }
+    }
+
+    public async Task<List<NpgmqSendTopicResult>> SendBatchTopicAsync<T>(string routingKey, IEnumerable<T> messages, int delay, CancellationToken cancellationToken = default) where T : class
+    {
+        try
+        {
+            var cmd = await _commandFactory.CreateAsync("SELECT queue_name, msg_id FROM pgmq.send_batch_topic(@routing_key, @msgs, @delay);", cancellationToken).ConfigureAwait(false);
+            await using (cmd.ConfigureAwait(false))
+            {
+                cmd.Parameters.AddWithValue("@routing_key", routingKey);
+                cmd.Parameters.AddWithValue("@msgs", NpgsqlDbType.Array | NpgsqlDbType.Jsonb, messages.Select(SerializeMessage).ToArray());
+                cmd.Parameters.AddWithValue("@delay", delay);
+                var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+                await using (reader.ConfigureAwait(false))
+                {
+                    return await ReadSendTopicResponsesAsync(reader, cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            throw new NpgmqException("Failed to send messages to topic.", ex);
+        }
+    }
+
+    public async Task<List<NpgmqSendTopicResult>> SendBatchTopicAsync<T>(string routingKey, IEnumerable<T> messages, DateTimeOffset delay, CancellationToken cancellationToken = default) where T : class
+    {
+        try
+        {
+            var cmd = await _commandFactory.CreateAsync("SELECT queue_name, msg_id FROM pgmq.send_batch_topic(@routing_key, @msgs, @delay);", cancellationToken).ConfigureAwait(false);
+            await using (cmd.ConfigureAwait(false))
+            {
+                cmd.Parameters.AddWithValue("@routing_key", routingKey);
+                cmd.Parameters.AddWithValue("@msgs", NpgsqlDbType.Array | NpgsqlDbType.Jsonb, messages.Select(SerializeMessage).ToArray());
+                cmd.Parameters.AddWithValue("@delay", delay.ToUniversalTime());
+                var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+                await using (reader.ConfigureAwait(false))
+                {
+                    return await ReadSendTopicResponsesAsync(reader, cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            throw new NpgmqException("Failed to send messages to topic.", ex);
+        }
+    }
+
+    public async Task<List<NpgmqSendTopicResult>> SendBatchTopicAsync<T>(string routingKey, IEnumerable<T> messages, IReadOnlyList<IReadOnlyDictionary<string, object>> headers, int delay, CancellationToken cancellationToken = default) where T : class
+    {
+        try
+        {
+            var cmd = await _commandFactory.CreateAsync("SELECT queue_name, msg_id FROM pgmq.send_batch_topic(@routing_key, @msgs, @headers, @delay);", cancellationToken).ConfigureAwait(false);
+            await using (cmd.ConfigureAwait(false))
+            {
+                cmd.Parameters.AddWithValue("@routing_key", routingKey);
+                cmd.Parameters.AddWithValue("@msgs", NpgsqlDbType.Array | NpgsqlDbType.Jsonb, messages.Select(SerializeMessage).ToArray());
+                cmd.Parameters.AddWithValue("@headers", NpgsqlDbType.Array | NpgsqlDbType.Jsonb, headers.Select(SerializeHeaders).ToArray());
+                cmd.Parameters.AddWithValue("@delay", delay);
+                var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+                await using (reader.ConfigureAwait(false))
+                {
+                    return await ReadSendTopicResponsesAsync(reader, cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            throw new NpgmqException("Failed to send messages to topic.", ex);
+        }
+    }
+
+    public async Task<List<NpgmqSendTopicResult>> SendBatchTopicAsync<T>(string routingKey, IEnumerable<T> messages, IReadOnlyList<IReadOnlyDictionary<string, object>> headers, DateTimeOffset delay, CancellationToken cancellationToken = default) where T : class
+    {
+        try
+        {
+            var cmd = await _commandFactory.CreateAsync("SELECT queue_name, msg_id FROM pgmq.send_batch_topic(@routing_key, @msgs, @headers, @delay);", cancellationToken).ConfigureAwait(false);
+            await using (cmd.ConfigureAwait(false))
+            {
+                cmd.Parameters.AddWithValue("@routing_key", routingKey);
+                cmd.Parameters.AddWithValue("@msgs", NpgsqlDbType.Array | NpgsqlDbType.Jsonb, messages.Select(SerializeMessage).ToArray());
+                cmd.Parameters.AddWithValue("@headers", NpgsqlDbType.Array | NpgsqlDbType.Jsonb, headers.Select(SerializeHeaders).ToArray());
+                cmd.Parameters.AddWithValue("@delay", delay.ToUniversalTime());
+                var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+                await using (reader.ConfigureAwait(false))
+                {
+                    return await ReadSendTopicResponsesAsync(reader, cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            throw new NpgmqException("Failed to send messages to topic.", ex);
+        }
+    }
+
+    private static async Task<List<NpgmqTopicBinding>> ReadTopicBindingsAsync(DbDataReader reader, CancellationToken cancellationToken = default)
+    {
+        var result = new List<NpgmqTopicBinding>();
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            result.Add(new NpgmqTopicBinding
+            {
+                Pattern = reader.GetString(0),
+                QueueName = reader.GetString(1),
+                BoundAt = reader.GetFieldValue<DateTimeOffset>(2),
+                CompiledRegex = reader.GetString(3)
+            });
+        }
+        return result;
+    }
+
+    private static async Task<List<NpgmqSendTopicResult>> ReadSendTopicResponsesAsync(DbDataReader reader, CancellationToken cancellationToken = default)
+    {
+        var result = new List<NpgmqSendTopicResult>();
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            result.Add(new NpgmqSendTopicResult
+            {
+                QueueName = reader.GetString(0),
+                MsgId = reader.GetInt64(1)
+            });
+        }
+        return result;
+    }
+}

--- a/Npgmq/NpgmqClient.Topic.cs
+++ b/Npgmq/NpgmqClient.Topic.cs
@@ -165,7 +165,7 @@ public partial class NpgmqClient
         }
     }
 
-    public async Task<List<NpgmqSendTopicResult>> SendBatchTopicAsync<T>(string routingKey, IEnumerable<T> messages, IReadOnlyList<IReadOnlyDictionary<string, object>> headers, CancellationToken cancellationToken = default) where T : class
+    public async Task<List<NpgmqSendTopicResult>> SendBatchTopicAsync<T>(string routingKey, IReadOnlyList<T> messages, IReadOnlyList<IReadOnlyDictionary<string, object>> headers, CancellationToken cancellationToken = default) where T : class
     {
         try
         {
@@ -234,7 +234,7 @@ public partial class NpgmqClient
         }
     }
 
-    public async Task<List<NpgmqSendTopicResult>> SendBatchTopicAsync<T>(string routingKey, IEnumerable<T> messages, IReadOnlyList<IReadOnlyDictionary<string, object>> headers, int delay, CancellationToken cancellationToken = default) where T : class
+    public async Task<List<NpgmqSendTopicResult>> SendBatchTopicAsync<T>(string routingKey, IReadOnlyList<T> messages, IReadOnlyList<IReadOnlyDictionary<string, object>> headers, int delay, CancellationToken cancellationToken = default) where T : class
     {
         try
         {
@@ -258,7 +258,7 @@ public partial class NpgmqClient
         }
     }
 
-    public async Task<List<NpgmqSendTopicResult>> SendBatchTopicAsync<T>(string routingKey, IEnumerable<T> messages, IReadOnlyList<IReadOnlyDictionary<string, object>> headers, DateTimeOffset delay, CancellationToken cancellationToken = default) where T : class
+    public async Task<List<NpgmqSendTopicResult>> SendBatchTopicAsync<T>(string routingKey, IReadOnlyList<T> messages, IReadOnlyList<IReadOnlyDictionary<string, object>> headers, DateTimeOffset delay, CancellationToken cancellationToken = default) where T : class
     {
         try
         {

--- a/Npgmq/NpgmqClient.cs
+++ b/Npgmq/NpgmqClient.cs
@@ -8,7 +8,7 @@ using NpgsqlTypes;
 namespace Npgmq;
 
 /// <inheritdoc cref="INpgmqClient" />
-public class NpgmqClient : INpgmqClient
+public partial class NpgmqClient : INpgmqClient
 {
     // Specialized JsonSerializerOptions to handle Dictionary<string, object> deserialization
     private static readonly JsonSerializerOptions DeserializationOptions = new()
@@ -64,11 +64,7 @@ public class NpgmqClient : INpgmqClient
                 return result is not null && Convert.ToBoolean(result);
             }
         }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             throw new NpgmqException($"Failed to archive message {msgId} in queue {queueName}.", ex);
         }
@@ -95,11 +91,7 @@ public class NpgmqClient : INpgmqClient
                 }
             }
         }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             throw new NpgmqException($"Failed to archive messages in queue {queueName}.", ex);
         }
@@ -116,11 +108,7 @@ public class NpgmqClient : INpgmqClient
                 await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
             }
         }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             throw new NpgmqException($"Failed to create queue {queueName}.", ex);
         }
@@ -137,11 +125,7 @@ public class NpgmqClient : INpgmqClient
                 await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
             }
         }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             throw new NpgmqException($"Failed to create unlogged queue {queueName}.", ex);
         }
@@ -160,11 +144,7 @@ public class NpgmqClient : INpgmqClient
                 return result is not null && Convert.ToBoolean(result);
             }
         }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             throw new NpgmqException($"Failed to delete message {msgId} from queue {queueName}.", ex);
         }
@@ -191,11 +171,7 @@ public class NpgmqClient : INpgmqClient
                 }
             }
         }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             throw new NpgmqException($"Failed to delete messages from queue {queueName}.", ex);
         }
@@ -213,11 +189,7 @@ public class NpgmqClient : INpgmqClient
                 return result is not null && Convert.ToBoolean(result);
             }
         }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             throw new NpgmqException($"Failed to drop queue {queueName}.", ex);
         }
@@ -233,11 +205,7 @@ public class NpgmqClient : INpgmqClient
                 await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
             }
         }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             throw new NpgmqException("Failed to initialize PGMQ extension.", ex);
         }
@@ -259,11 +227,7 @@ public class NpgmqClient : INpgmqClient
                 };
             }
         }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             throw new NpgmqException("Failed to get PGMQ version.", ex);
         }
@@ -297,11 +261,7 @@ public class NpgmqClient : INpgmqClient
                 }
             }
         }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             throw new NpgmqException("Failed to list queues.", ex);
         }
@@ -314,11 +274,7 @@ public class NpgmqClient : INpgmqClient
             var result = await PollBatchAsync<T>(queueName, vt, 1, pollTimeoutSeconds, pollIntervalMilliseconds, cancellationToken).ConfigureAwait(false);
             return result.SingleOrDefault();
         }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             throw new NpgmqException($"Failed to poll queue {queueName}.", ex);
         }
@@ -343,11 +299,7 @@ public class NpgmqClient : INpgmqClient
                 }
             }
         }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             throw new NpgmqException($"Failed to poll queue {queueName}.", ex);
         }
@@ -369,11 +321,7 @@ public class NpgmqClient : INpgmqClient
                 }
             }
         }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             throw new NpgmqException($"Failed to pop queue {queueName}.", ex);
         }
@@ -395,11 +343,7 @@ public class NpgmqClient : INpgmqClient
                 }
             }
         }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             throw new NpgmqException($"Failed to pop queue {queueName}.", ex);
         }
@@ -417,11 +361,7 @@ public class NpgmqClient : INpgmqClient
                 return Convert.ToInt64(result!);
             }
         }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             throw new NpgmqException($"Failed to purge queue {queueName}.", ex);
         }
@@ -439,11 +379,7 @@ public class NpgmqClient : INpgmqClient
                 return Convert.ToInt32(result ?? 0) == 1;
             }
         }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             throw new NpgmqException($"Failed to check if queue {queueName} exists.", ex);
         }
@@ -456,11 +392,7 @@ public class NpgmqClient : INpgmqClient
             var result = await ReadBatchAsync<T>(queueName, vt, 1, cancellationToken).ConfigureAwait(false);
             return result.SingleOrDefault();
         }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             throw new NpgmqException($"Failed to read from queue {queueName}.", ex);
         }
@@ -483,11 +415,7 @@ public class NpgmqClient : INpgmqClient
                 }
             }
         }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             throw new NpgmqException($"Failed to read from queue {queueName}.", ex);
         }
@@ -506,11 +434,7 @@ public class NpgmqClient : INpgmqClient
                 return Convert.ToInt64(result!);
             }
         }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             throw new NpgmqException($"Failed to send message to queue {queueName}.", ex);
         }
@@ -530,11 +454,7 @@ public class NpgmqClient : INpgmqClient
                 return Convert.ToInt64(result!);
             }
         }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             throw new NpgmqException($"Failed to send message to queue {queueName}.", ex);
         }
@@ -554,11 +474,7 @@ public class NpgmqClient : INpgmqClient
                 return Convert.ToInt64(result!);
             }
         }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             throw new NpgmqException($"Failed to send message to queue {queueName}.", ex);
         }
@@ -578,11 +494,7 @@ public class NpgmqClient : INpgmqClient
                 return Convert.ToInt64(result!);
             }
         }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             throw new NpgmqException($"Failed to send message to queue {queueName}.", ex);
         }
@@ -603,11 +515,7 @@ public class NpgmqClient : INpgmqClient
                 return Convert.ToInt64(result!);
             }
         }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             throw new NpgmqException($"Failed to send message to queue {queueName}.", ex);
         }
@@ -628,11 +536,7 @@ public class NpgmqClient : INpgmqClient
                 return Convert.ToInt64(result!);
             }
         }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             throw new NpgmqException($"Failed to send message to queue {queueName}.", ex);
         }
@@ -659,11 +563,7 @@ public class NpgmqClient : INpgmqClient
                 }
             }
         }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             throw new NpgmqException($"Failed to send messages to queue {queueName}.", ex);
         }
@@ -691,11 +591,7 @@ public class NpgmqClient : INpgmqClient
                 }
             }
         }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             throw new NpgmqException($"Failed to send messages to queue {queueName}.", ex);
         }
@@ -723,11 +619,7 @@ public class NpgmqClient : INpgmqClient
                 }
             }
         }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             throw new NpgmqException($"Failed to send messages to queue {queueName}.", ex);
         }
@@ -755,11 +647,7 @@ public class NpgmqClient : INpgmqClient
                 }
             }
         }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             throw new NpgmqException($"Failed to send messages to queue {queueName}.", ex);
         }
@@ -788,11 +676,7 @@ public class NpgmqClient : INpgmqClient
                 }
             }
         }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             throw new NpgmqException($"Failed to send messages to queue {queueName}.", ex);
         }
@@ -821,11 +705,7 @@ public class NpgmqClient : INpgmqClient
                 }
             }
         }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             throw new NpgmqException($"Failed to send messages to queue {queueName}.", ex);
         }
@@ -844,11 +724,7 @@ public class NpgmqClient : INpgmqClient
                 await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
             }
         }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             throw new NpgmqException($"Failed to set VT for message {msgId} in queue {queueName}.", ex);
         }
@@ -867,11 +743,7 @@ public class NpgmqClient : INpgmqClient
                 await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
             }
         }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             throw new NpgmqException($"Failed to set VT for message {msgId} in queue {queueName}.", ex);
         }
@@ -899,11 +771,7 @@ public class NpgmqClient : INpgmqClient
                 }
             }
         }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             throw new NpgmqException($"Failed to set VT for messages in queue {queueName}.", ex);
         }
@@ -931,11 +799,7 @@ public class NpgmqClient : INpgmqClient
                 }
             }
         }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             throw new NpgmqException($"Failed to set VT for messages in queue {queueName}.", ex);
         }
@@ -955,11 +819,7 @@ public class NpgmqClient : INpgmqClient
                 }
             }
         }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             throw new NpgmqException("Failed to get metrics.", ex);
         }
@@ -986,11 +846,7 @@ public class NpgmqClient : INpgmqClient
                 }
             }
         }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             throw new NpgmqException($"Failed to get metrics for queue {queueName}.", ex);
         }
@@ -1032,10 +888,10 @@ public class NpgmqClient : INpgmqClient
         return result;
     }
 
-    private static string SerializeMessage<T>(T message) where T : class =>
+    private static string SerializeMessage<T>(T message) =>
         typeof(T) == typeof(string) ? message as string ?? "" : JsonSerializer.Serialize(message);
 
-    private static T? DeserializeMessage<T>(string message) where T : class =>
+    private static T? DeserializeMessage<T>(string message) =>
         typeof(T) == typeof(string) ? (T?)(object?)message : JsonSerializer.Deserialize<T?>(message, DeserializationOptions);
 
     private static string SerializeHeaders(IReadOnlyDictionary<string, object> headers) =>

--- a/Npgmq/NpgmqCommandFactory.cs
+++ b/Npgmq/NpgmqCommandFactory.cs
@@ -12,17 +12,17 @@ internal class NpgmqCommandFactory
 
     public NpgmqCommandFactory(NpgsqlDataSource dataSource)
     {
-        _dataSource = dataSource;
+        _dataSource = dataSource ?? throw new ArgumentNullException(nameof(dataSource));
     }
 
     public NpgmqCommandFactory(NpgsqlConnection connection)
     {
-        _connection = connection;
+        _connection = connection ?? throw new ArgumentNullException(nameof(connection));
     }
 
     public NpgmqCommandFactory(string connectionString)
     {
-        _connectionString = connectionString;
+        _connectionString = connectionString ?? throw new ArgumentNullException(nameof(connectionString));
     }
 
     public async Task<NpgmqCommand> CreateAsync(string commandText, CancellationToken cancellationToken = default)

--- a/Npgmq/NpgmqSendTopicResult.cs
+++ b/Npgmq/NpgmqSendTopicResult.cs
@@ -1,0 +1,17 @@
+namespace Npgmq;
+
+/// <summary>
+/// Result of sending a message to a topic.
+/// </summary>
+public class NpgmqSendTopicResult
+{
+    /// <summary>
+    /// The queue name where the message was sent.
+    /// </summary>
+    public string QueueName { get; set; } = null!;
+
+    /// <summary>
+    /// Unique identifier for the message.
+    /// </summary>
+    public long MsgId { get; set; }
+}

--- a/Npgmq/NpgmqTopicBinding.cs
+++ b/Npgmq/NpgmqTopicBinding.cs
@@ -1,0 +1,27 @@
+namespace Npgmq;
+
+/// <summary>
+/// PGMQ Topic binding.
+/// </summary>
+public class NpgmqTopicBinding
+{
+    /// <summary>
+    /// Wildcard pattern for routing key matching.
+    /// </summary>
+    public string Pattern { get; set; } = null!;
+
+    /// <summary>
+    /// Name of the queue that receives messages when pattern matches.
+    /// </summary>
+    public string QueueName { get; set; } = null!;
+
+    /// <summary>
+    /// Timestamp when the binding was created.
+    /// </summary>
+    public DateTimeOffset BoundAt { get; set; }
+
+    /// <summary>
+    /// Compiled regex for the wildcard pattern.
+    /// </summary>
+    public string CompiledRegex { get; set; } = null!;
+}

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ using Npgmq;
 
 var npgmq = new NpgmqClient("<YOUR CONNECTION STRING HERE>");
 
-await npgmq.InitAsync();
+await npgmq.InitAsync(); // Optional (ensures the pgmq extension has been created in postgres)
 
 await npgmq.CreateQueueAsync("my_queue");
 
@@ -144,6 +144,7 @@ Npgmq is tested with pgmq versions 1.5.1 and higher.
 Some features require minimum versions of the pgmq extension:
 * PopAsync(queue, qty): Requires pgmq 1.7.0+
 * SetVtBatchAsync: Requires pgmq 1.8.0+
+* Topic Support: Requires pgmq 1.11.0+
 
 You can check the installed version:
 ```csharp


### PR DESCRIPTION
## Summary

Adds pgmq topic routing support to `NpgmqClient` for pgmq `1.11.0+`.

## What Changed

- added topic binding APIs:
  - `BindTopicAsync`
  - `UnbindTopicAsync`
  - `ListTopicBindingsAsync`
- added topic send APIs:
  - `SendTopicAsync`
  - `SendBatchTopicAsync`
- simplified exception handling while preserving cancellation behavior
- updated the console example to demonstrate topic routing
- refreshed README/example/contributing text
- bumped several package dependencies
