### PR TITLE
Add support for reading and polling grouped messages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,48 +44,65 @@ jobs:
       - name: Build
         run: dotnet build --no-restore --configuration Release /p:Version=${{ env.VERSION }} /p:CopyrightYear=$(date +%Y)
 
-      - name: Test (latest pgmq version)
-        run: Npgmq.Test/scripts/run-tests.sh
+  test:
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        pgmq-version:
+          - latest
+          - 1.11.1
+          - 1.11.0
+          - 1.10.0
+          - 1.9.0
+          - 1.8.1
+          - 1.8.0
+          - 1.7.0
+          - 1.6.1
+          - 1.6.0
+          - 1.5.1
+    name: Test pgmq ${{ matrix.pgmq-version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}  # This checks out the commit that triggered the workflow run
 
-      - name: Test (pgmq 1.11.0)
-        run: Npgmq.Test/scripts/run-tests.sh 1.11.0
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
 
-      - name: Test (pgmq 1.10.0)
-        run: Npgmq.Test/scripts/run-tests.sh 1.10.0
+      - name: Test
+        run: Npgmq.Test/scripts/run-tests.sh ${{ matrix.pgmq-version }}
 
-      - name: Test (pgmq 1.9.0)
-        run: Npgmq.Test/scripts/run-tests.sh 1.9.0
+  pack:
+    needs: [build, test]
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}  # This checks out the commit that triggered the workflow run
 
-      - name: Test (pgmq 1.8.1)
-        run: Npgmq.Test/scripts/run-tests.sh 1.8.1
-               
-      - name: Test (pgmq 1.8.0)
-        run: Npgmq.Test/scripts/run-tests.sh 1.8.0
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
 
-      - name: Test (pgmq 1.7.0)
-        run: Npgmq.Test/scripts/run-tests.sh 1.7.0
-
-      - name: Test (pgmq 1.6.1)
-        run: Npgmq.Test/scripts/run-tests.sh 1.6.1
-
-      - name: Test (pgmq 1.6.0)
-        run: Npgmq.Test/scripts/run-tests.sh 1.6.0
-
-      - name: Test (pgmq 1.5.1)
-        run: Npgmq.Test/scripts/run-tests.sh 1.5.1
+      - name: Set the version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
 
       - name: Pack
-        if: startsWith(github.ref, 'refs/tags/v')
-        run: dotnet pack Npgmq/Npgmq.csproj --no-build --configuration Release /p:PackageVersion=${{ env.VERSION }} /p:CopyrightYear=$(date +%Y) --output out
+        run: dotnet pack Npgmq/Npgmq.csproj --configuration Release /p:Version=${{ env.VERSION }} /p:PackageVersion=${{ env.VERSION }} /p:CopyrightYear=$(date +%Y) --output out
 
       - uses: actions/upload-artifact@v4
-        if: startsWith(github.ref, 'refs/tags/v')
         with:
           name: build-artifact
           path: out
 
   publish:
-    needs: build
+    needs: pack
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,12 +19,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.ref }}  # This checks out the commit that triggered the workflow run
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
 
@@ -64,12 +64,12 @@ jobs:
           - 1.5.1
     name: Test pgmq ${{ matrix.pgmq-version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.ref }}  # This checks out the commit that triggered the workflow run
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
 
@@ -81,12 +81,12 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.ref }}  # This checks out the commit that triggered the workflow run
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
 
@@ -96,7 +96,7 @@ jobs:
       - name: Pack
         run: dotnet pack Npgmq/Npgmq.csproj --configuration Release /p:Version=${{ env.VERSION }} /p:PackageVersion=${{ env.VERSION }} /p:CopyrightYear=$(date +%Y) --output out
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: build-artifact
           path: out
@@ -106,13 +106,13 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: build-artifact
           path: out
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Test (latest pgmq version)
         run: Npgmq.Test/scripts/run-tests.sh
 
+      - name: Test (pgmq 1.11.0)
+        run: Npgmq.Test/scripts/run-tests.sh 1.11.0
+
       - name: Test (pgmq 1.10.0)
         run: Npgmq.Test/scripts/run-tests.sh 1.10.0
 

--- a/Npgmq.Example.Console/Npgmq.Example.Console.csproj
+++ b/Npgmq.Example.Console/Npgmq.Example.Console.csproj
@@ -13,8 +13,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.5" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.5" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.6" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.6" />
     </ItemGroup>
 
 </Project>

--- a/Npgmq.Test/Npgmq.Test.csproj
+++ b/Npgmq.Test/Npgmq.Test.csproj
@@ -14,9 +14,9 @@
     <ItemGroup>
         <PackageReference Include="Dapper" Version="2.1.72" />
         <PackageReference Include="DeepEqual" Version="5.1.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.5" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.5" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.6" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.6" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.6" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/Npgmq.Test/NpgmqClientStressTest.cs
+++ b/Npgmq.Test/NpgmqClientStressTest.cs
@@ -28,8 +28,8 @@ public class NpgmqClientStressTest(PostgresFixture postgresFixture) : IClassFixt
     {
         // Arrange
         const int totalMessages = 20_000;
-        const int producerCount = 50;
-        const int consumerCount = 50;
+        const int producerCount = 40; // Keep total producer + consumer count below postgres max connections
+        const int consumerCount = 40;
 
         var seen = new ConcurrentDictionary<int, int>(); // id -> count
         var produced = Enumerable.Range(1, totalMessages).ToArray();
@@ -76,8 +76,8 @@ public class NpgmqClientStressTest(PostgresFixture postgresFixture) : IClassFixt
     {
         // Arrange
         const int totalMessages = 20_000;
-        const int producerCount = 50;
-        const int consumerCount = 50;
+        const int producerCount = 40; // Keep total producer + consumer count below postgres max connections
+        const int consumerCount = 40;
 
         var seen = new ConcurrentDictionary<int, int>(); // id -> count
         var produced = Enumerable.Range(1, totalMessages).ToArray();

--- a/Npgmq.Test/NpgmqClientTest.Grouped.cs
+++ b/Npgmq.Test/NpgmqClientTest.Grouped.cs
@@ -1,0 +1,203 @@
+using DeepEqual.Syntax;
+
+namespace Npgmq.Test;
+
+public partial class NpgmqClientTest
+{
+    [SkippableFact]
+    public async Task PollGroupedAsync_should_wait_for_multiple_grouped_messages()
+    {
+        Skip.IfNot(await IsMinPgmqVersion("1.9.0"), "requires pgmq 1.9.0 or later.");
+
+        // Arrange
+        await _sut.CreateQueueAsync(_testQueueName);
+
+        // Act
+        var pollTask = _sut.PollGroupedAsync<TestMessage>(_testQueueName, limit: 3);
+
+        // Wait a little bit and then send some messages
+        await Task.Delay(1000);
+        var producer = new NpgmqClient(_postgresFixture.DataSource);
+        var msgIds = await producer.SendBatchAsync(
+            _testQueueName,
+            [
+                new TestMessage { Foo = 1 },
+                new TestMessage { Foo = 2 },
+                new TestMessage { Foo = 3 },
+                new TestMessage { Foo = 4 },
+                new TestMessage { Foo = 5 }
+            ],
+            [
+                NpgmqHeaders.From(NpgmqHeaders.XPgmqGroup, "group1"),
+                NpgmqHeaders.From(NpgmqHeaders.XPgmqGroup, "group2"),
+                NpgmqHeaders.From(NpgmqHeaders.XPgmqGroup, "group2"),
+                NpgmqHeaders.From(NpgmqHeaders.XPgmqGroup, "group1"),
+                NpgmqHeaders.From(NpgmqHeaders.XPgmqGroup, "group1")
+            ]
+        );
+
+        // Get the messages received by the poll
+        var messages = await pollTask;
+
+        // Assert
+        messages.Select(m => m.MsgId).ShouldDeepEqual(new[] { msgIds[0], msgIds[3], msgIds[4] });
+        Assert.All(messages, m => Assert.NotNull(m.Headers));
+    }
+
+    [SkippableFact]
+    public async Task PollGroupedRoundRobinAsync_should_wait_for_multiple_grouped_messages_using_round_robin()
+    {
+        Skip.IfNot(await IsMinPgmqVersion("1.9.0"), "requires pgmq 1.9.0 or later.");
+
+        // Arrange
+        await _sut.CreateQueueAsync(_testQueueName);
+
+        // Act
+        var pollTask = _sut.PollGroupedRoundRobinAsync<TestMessage>(_testQueueName, limit: 3);
+
+        // Wait a little bit and then send some messages
+        await Task.Delay(1000);
+        var producer = new NpgmqClient(_postgresFixture.DataSource);
+        var msgIds = await producer.SendBatchAsync(
+            _testQueueName,
+            [
+                new TestMessage { Foo = 1 },
+                new TestMessage { Foo = 2 },
+                new TestMessage { Foo = 3 },
+                new TestMessage { Foo = 4 },
+                new TestMessage { Foo = 5 }
+            ],
+            [
+                NpgmqHeaders.From(NpgmqHeaders.XPgmqGroup, "group1"),
+                NpgmqHeaders.From(NpgmqHeaders.XPgmqGroup, "group1"),
+                NpgmqHeaders.From(NpgmqHeaders.XPgmqGroup, "group1"),
+                NpgmqHeaders.From(NpgmqHeaders.XPgmqGroup, "group2"),
+                NpgmqHeaders.From(NpgmqHeaders.XPgmqGroup, "group2")
+            ]
+        );
+
+        // Get the messages received by the poll
+        var messages = await pollTask;
+
+        // Assert
+        messages.Select(m => m.MsgId).ShouldDeepEqual(new[] { msgIds[0], msgIds[3], msgIds[1] });
+        Assert.All(messages, m => Assert.NotNull(m.Headers));
+    }
+
+    [SkippableFact]
+    public async Task ReadGroupedAsync_should_read_grouped_messages()
+    {
+        Skip.IfNot(await IsMinPgmqVersion("1.9.0"), "requires pgmq 1.9.0 or later.");
+
+        // Arrange
+        await _sut.CreateQueueAsync(_testQueueName);
+
+        // Act
+        var msgIds = new List<long>
+        {
+            await _sut.SendAsync(_testQueueName, new TestMessage { Foo = 1 }, NpgmqHeaders.From(NpgmqHeaders.XPgmqGroup, "group1")),
+            await _sut.SendAsync(_testQueueName, new TestMessage { Foo = 2 }, NpgmqHeaders.From(NpgmqHeaders.XPgmqGroup, "group2")),
+            await _sut.SendAsync(_testQueueName, new TestMessage { Foo = 3 }, NpgmqHeaders.From(NpgmqHeaders.XPgmqGroup, "group2")),
+            await _sut.SendAsync(_testQueueName, new TestMessage { Foo = 4 }, NpgmqHeaders.From(NpgmqHeaders.XPgmqGroup, "group1")),
+            await _sut.SendAsync(_testQueueName, new TestMessage { Foo = 5 }, NpgmqHeaders.From(NpgmqHeaders.XPgmqGroup, "group1"))
+        };
+        var messages = await _sut.ReadGroupedAsync<TestMessage>(_testQueueName, limit: 3);
+
+        // Assert
+        messages.Select(x => x.MsgId).ShouldDeepEqual(new[] { msgIds[0], msgIds[3], msgIds[4] });
+        Assert.True(messages.All(x => x.Headers != null));
+    }
+
+    [SkippableFact]
+    public async Task ReadGroupedAsync_should_handle_no_messages()
+    {
+        Skip.IfNot(await IsMinPgmqVersion("1.9.0"), "requires pgmq 1.9.0 or later.");
+
+        // Arrange
+        await _sut.CreateQueueAsync(_testQueueName);
+
+        // Act
+        var messages = await _sut.ReadGroupedAsync<TestMessage>(_testQueueName);
+
+        // Assert
+        Assert.Empty(messages);
+    }
+
+    [SkippableFact]
+    public async Task ReadGroupedRoundRobinAsync_should_read_grouped_messages_using_round_robin()
+    {
+        Skip.IfNot(await IsMinPgmqVersion("1.9.0"), "requires pgmq 1.9.0 or later.");
+
+        // Arrange
+        await _sut.CreateQueueAsync(_testQueueName);
+
+        // Act
+        var msgIds = new List<long>
+        {
+            await _sut.SendAsync(_testQueueName, new TestMessage { Foo = 1 }, NpgmqHeaders.From(NpgmqHeaders.XPgmqGroup, "group1")),
+            await _sut.SendAsync(_testQueueName, new TestMessage { Foo = 2 }, NpgmqHeaders.From(NpgmqHeaders.XPgmqGroup, "group1")),
+            await _sut.SendAsync(_testQueueName, new TestMessage { Foo = 3 }, NpgmqHeaders.From(NpgmqHeaders.XPgmqGroup, "group1")),
+            await _sut.SendAsync(_testQueueName, new TestMessage { Foo = 4 }, NpgmqHeaders.From(NpgmqHeaders.XPgmqGroup, "group2")),
+            await _sut.SendAsync(_testQueueName, new TestMessage { Foo = 5 }, NpgmqHeaders.From(NpgmqHeaders.XPgmqGroup, "group2"))
+        };
+        var messages = await _sut.ReadGroupedRoundRobinAsync<TestMessage>(_testQueueName, limit: 3);
+
+        // Assert
+        messages.Select(x => x.MsgId).ShouldDeepEqual(new[] { msgIds[0], msgIds[3], msgIds[1] });
+        Assert.All(messages, m => Assert.NotNull(m.Headers));
+    }
+
+    [SkippableFact]
+    public async Task ReadGroupedRoundRobinAsync_should_handle_no_messages()
+    {
+        Skip.IfNot(await IsMinPgmqVersion("1.9.0"), "requires pgmq 1.9.0 or later.");
+
+        // Arrange
+        await _sut.CreateQueueAsync(_testQueueName);
+
+        // Act
+        var messages = await _sut.ReadGroupedRoundRobinAsync<TestMessage>(_testQueueName);
+
+        // Assert
+        Assert.Empty(messages);
+    }
+
+    [SkippableFact]
+    public async Task ReadGroupedHeadAsync_should_read_grouped_head_messages()
+    {
+        Skip.IfNot(await IsMinPgmqVersion("1.11.1"), "requires pgmq 1.11.1 or later.");
+
+        // Arrange
+        await _sut.CreateQueueAsync(_testQueueName);
+
+        // Act
+        var msgIds = new List<long>
+        {
+            await _sut.SendAsync(_testQueueName, new TestMessage { Foo = 1 }, NpgmqHeaders.From(NpgmqHeaders.XPgmqGroup, "group1")),
+            await _sut.SendAsync(_testQueueName, new TestMessage { Foo = 2 }, NpgmqHeaders.From(NpgmqHeaders.XPgmqGroup, "group1")),
+            await _sut.SendAsync(_testQueueName, new TestMessage { Foo = 3 }, NpgmqHeaders.From(NpgmqHeaders.XPgmqGroup, "group1")),
+            await _sut.SendAsync(_testQueueName, new TestMessage { Foo = 4 }, NpgmqHeaders.From(NpgmqHeaders.XPgmqGroup, "group2")),
+            await _sut.SendAsync(_testQueueName, new TestMessage { Foo = 5 }, NpgmqHeaders.From(NpgmqHeaders.XPgmqGroup, "group2"))
+        };
+        var messages = await _sut.ReadGroupedHeadAsync<TestMessage>(_testQueueName);
+
+        // Assert
+        messages.Select(x => x.MsgId).ShouldDeepEqual(new[] { msgIds[0], msgIds[3] });
+        Assert.All(messages, m => Assert.NotNull(m.Headers));
+    }
+
+    [SkippableFact]
+    public async Task ReadGroupedHeadAsync_should_handle_no_messages()
+    {
+        Skip.IfNot(await IsMinPgmqVersion("1.11.1"), "requires pgmq 1.11.1 or later.");
+
+        // Arrange
+        await _sut.CreateQueueAsync(_testQueueName);
+
+        // Act
+        var messages = await _sut.ReadGroupedHeadAsync<TestMessage>(_testQueueName);
+
+        // Assert
+        Assert.Empty(messages);
+    }
+}

--- a/Npgmq.Test/NpgmqClientTest.Grouped.cs
+++ b/Npgmq.Test/NpgmqClientTest.Grouped.cs
@@ -28,11 +28,11 @@ public partial class NpgmqClientTest
                 new TestMessage { Foo = 5 }
             ],
             [
-                NpgmqHeaders.From(NpgmqHeaders.XPgmqGroup, "group1"),
-                NpgmqHeaders.From(NpgmqHeaders.XPgmqGroup, "group2"),
-                NpgmqHeaders.From(NpgmqHeaders.XPgmqGroup, "group2"),
-                NpgmqHeaders.From(NpgmqHeaders.XPgmqGroup, "group1"),
-                NpgmqHeaders.From(NpgmqHeaders.XPgmqGroup, "group1")
+                NpgmqHeaders.From("x-pgmq-group", "group1"),
+                NpgmqHeaders.From("x-pgmq-group", "group2"),
+                NpgmqHeaders.From("x-pgmq-group", "group2"),
+                NpgmqHeaders.From("x-pgmq-group", "group1"),
+                NpgmqHeaders.From("x-pgmq-group", "group1")
             ]
         );
 
@@ -68,11 +68,11 @@ public partial class NpgmqClientTest
                 new TestMessage { Foo = 5 }
             ],
             [
-                NpgmqHeaders.From(NpgmqHeaders.XPgmqGroup, "group1"),
-                NpgmqHeaders.From(NpgmqHeaders.XPgmqGroup, "group1"),
-                NpgmqHeaders.From(NpgmqHeaders.XPgmqGroup, "group1"),
-                NpgmqHeaders.From(NpgmqHeaders.XPgmqGroup, "group2"),
-                NpgmqHeaders.From(NpgmqHeaders.XPgmqGroup, "group2")
+                NpgmqHeaders.From("x-pgmq-group", "group1"),
+                NpgmqHeaders.From("x-pgmq-group", "group1"),
+                NpgmqHeaders.From("x-pgmq-group", "group1"),
+                NpgmqHeaders.From("x-pgmq-group", "group2"),
+                NpgmqHeaders.From("x-pgmq-group", "group2")
             ]
         );
 
@@ -95,11 +95,11 @@ public partial class NpgmqClientTest
         // Act
         var msgIds = new List<long>
         {
-            await _sut.SendAsync(_testQueueName, new TestMessage { Foo = 1 }, NpgmqHeaders.From(NpgmqHeaders.XPgmqGroup, "group1")),
-            await _sut.SendAsync(_testQueueName, new TestMessage { Foo = 2 }, NpgmqHeaders.From(NpgmqHeaders.XPgmqGroup, "group2")),
-            await _sut.SendAsync(_testQueueName, new TestMessage { Foo = 3 }, NpgmqHeaders.From(NpgmqHeaders.XPgmqGroup, "group2")),
-            await _sut.SendAsync(_testQueueName, new TestMessage { Foo = 4 }, NpgmqHeaders.From(NpgmqHeaders.XPgmqGroup, "group1")),
-            await _sut.SendAsync(_testQueueName, new TestMessage { Foo = 5 }, NpgmqHeaders.From(NpgmqHeaders.XPgmqGroup, "group1"))
+            await _sut.SendAsync(_testQueueName, new TestMessage { Foo = 1 }, NpgmqHeaders.From("x-pgmq-group", "group1")),
+            await _sut.SendAsync(_testQueueName, new TestMessage { Foo = 2 }, NpgmqHeaders.From("x-pgmq-group", "group2")),
+            await _sut.SendAsync(_testQueueName, new TestMessage { Foo = 3 }, NpgmqHeaders.From("x-pgmq-group", "group2")),
+            await _sut.SendAsync(_testQueueName, new TestMessage { Foo = 4 }, NpgmqHeaders.From("x-pgmq-group", "group1")),
+            await _sut.SendAsync(_testQueueName, new TestMessage { Foo = 5 }, NpgmqHeaders.From("x-pgmq-group", "group1"))
         };
         var messages = await _sut.ReadGroupedAsync<TestMessage>(_testQueueName, limit: 3);
 
@@ -134,11 +134,11 @@ public partial class NpgmqClientTest
         // Act
         var msgIds = new List<long>
         {
-            await _sut.SendAsync(_testQueueName, new TestMessage { Foo = 1 }, NpgmqHeaders.From(NpgmqHeaders.XPgmqGroup, "group1")),
-            await _sut.SendAsync(_testQueueName, new TestMessage { Foo = 2 }, NpgmqHeaders.From(NpgmqHeaders.XPgmqGroup, "group1")),
-            await _sut.SendAsync(_testQueueName, new TestMessage { Foo = 3 }, NpgmqHeaders.From(NpgmqHeaders.XPgmqGroup, "group1")),
-            await _sut.SendAsync(_testQueueName, new TestMessage { Foo = 4 }, NpgmqHeaders.From(NpgmqHeaders.XPgmqGroup, "group2")),
-            await _sut.SendAsync(_testQueueName, new TestMessage { Foo = 5 }, NpgmqHeaders.From(NpgmqHeaders.XPgmqGroup, "group2"))
+            await _sut.SendAsync(_testQueueName, new TestMessage { Foo = 1 }, NpgmqHeaders.From("x-pgmq-group", "group1")),
+            await _sut.SendAsync(_testQueueName, new TestMessage { Foo = 2 }, NpgmqHeaders.From("x-pgmq-group", "group1")),
+            await _sut.SendAsync(_testQueueName, new TestMessage { Foo = 3 }, NpgmqHeaders.From("x-pgmq-group", "group1")),
+            await _sut.SendAsync(_testQueueName, new TestMessage { Foo = 4 }, NpgmqHeaders.From("x-pgmq-group", "group2")),
+            await _sut.SendAsync(_testQueueName, new TestMessage { Foo = 5 }, NpgmqHeaders.From("x-pgmq-group", "group2"))
         };
         var messages = await _sut.ReadGroupedRoundRobinAsync<TestMessage>(_testQueueName, limit: 3);
 
@@ -173,11 +173,11 @@ public partial class NpgmqClientTest
         // Act
         var msgIds = new List<long>
         {
-            await _sut.SendAsync(_testQueueName, new TestMessage { Foo = 1 }, NpgmqHeaders.From(NpgmqHeaders.XPgmqGroup, "group1")),
-            await _sut.SendAsync(_testQueueName, new TestMessage { Foo = 2 }, NpgmqHeaders.From(NpgmqHeaders.XPgmqGroup, "group1")),
-            await _sut.SendAsync(_testQueueName, new TestMessage { Foo = 3 }, NpgmqHeaders.From(NpgmqHeaders.XPgmqGroup, "group1")),
-            await _sut.SendAsync(_testQueueName, new TestMessage { Foo = 4 }, NpgmqHeaders.From(NpgmqHeaders.XPgmqGroup, "group2")),
-            await _sut.SendAsync(_testQueueName, new TestMessage { Foo = 5 }, NpgmqHeaders.From(NpgmqHeaders.XPgmqGroup, "group2"))
+            await _sut.SendAsync(_testQueueName, new TestMessage { Foo = 1 }, NpgmqHeaders.From("x-pgmq-group", "group1")),
+            await _sut.SendAsync(_testQueueName, new TestMessage { Foo = 2 }, NpgmqHeaders.From("x-pgmq-group", "group1")),
+            await _sut.SendAsync(_testQueueName, new TestMessage { Foo = 3 }, NpgmqHeaders.From("x-pgmq-group", "group1")),
+            await _sut.SendAsync(_testQueueName, new TestMessage { Foo = 4 }, NpgmqHeaders.From("x-pgmq-group", "group2")),
+            await _sut.SendAsync(_testQueueName, new TestMessage { Foo = 5 }, NpgmqHeaders.From("x-pgmq-group", "group2"))
         };
         var messages = await _sut.ReadGroupedHeadAsync<TestMessage>(_testQueueName);
 

--- a/Npgmq.Test/NpgmqClientTest.Grouped.cs
+++ b/Npgmq.Test/NpgmqClientTest.Grouped.cs
@@ -200,4 +200,28 @@ public partial class NpgmqClientTest
         // Assert
         Assert.Empty(messages);
     }
+
+    [SkippableFact]
+    public async Task CreateFifoIndexAsync_should_create_fifo_index()
+    {
+        Skip.IfNot(await IsMinPgmqVersion("1.9.0"), "requires pgmq 1.9.0 or later.");
+
+        // Arrange
+        await _sut.CreateQueueAsync(_testQueueName);
+
+        // Act
+        await _sut.CreateFifoIndexAsync(_testQueueName);
+    }
+
+    [SkippableFact]
+    public async Task CreateFifoIndexesAsync_should_create_fifo_indexes()
+    {
+        Skip.IfNot(await IsMinPgmqVersion("1.9.0"), "requires pgmq 1.9.0 or later.");
+
+        // Arrange
+        await _sut.CreateQueueAsync(_testQueueName);
+
+        // Act
+        await _sut.CreateFifoIndexesAsync();
+    }
 }

--- a/Npgmq.Test/NpgmqClientTest.cs
+++ b/Npgmq.Test/NpgmqClientTest.cs
@@ -545,11 +545,7 @@ public sealed partial class NpgmqClientTest : IClassFixture<PostgresFixture>, IA
         await _sut.CreateQueueAsync(_testQueueName);
 
         // Act
-        var headers = new Dictionary<string, object>()
-        {
-            { "CorrelationId", "abc-123" },
-            { "Priority", 5 }
-        };
+        var headers = NpgmqHeaders.From(("CorrelationId", "abc-123"), ("Priority", 5));
         var msgId = await _sut.SendAsync(_testQueueName, new TestMessage
         {
             Foo = 123,
@@ -746,11 +742,7 @@ public sealed partial class NpgmqClientTest : IClassFixture<PostgresFixture>, IA
         await _sut.CreateQueueAsync(_testQueueName);
 
         // Act
-        var headers = new Dictionary<string, object>()
-        {
-            { "CorrelationId", "abc-123" },
-            { "Priority", 5 }
-        };
+        var headers = NpgmqHeaders.From(("CorrelationId", "abc-123"), ("Priority", 5));
         var msgId = await _sut.SendAsync(_testQueueName, new TestMessage
         {
             Foo = 123,
@@ -888,9 +880,9 @@ public sealed partial class NpgmqClientTest : IClassFixture<PostgresFixture>, IA
         // Act
         var msgIds = new List<long>
         {
-            await _sut.SendAsync(_testQueueName, new TestMessage { Foo = 1 }, new Dictionary<string, object> { { "header1", "aaa" } } ),
-            await _sut.SendAsync(_testQueueName, new TestMessage { Foo = 2 }, new Dictionary<string, object> { { "header1", "bbb" }, { "header2", 987 } }),
-            await _sut.SendAsync(_testQueueName, new TestMessage { Foo = 3 }, new Dictionary<string, object> { { "header1", "ccc" } } )
+            await _sut.SendAsync(_testQueueName, new TestMessage { Foo = 1 }, NpgmqHeaders.From("header1", "aaa")),
+            await _sut.SendAsync(_testQueueName, new TestMessage { Foo = 2 }, NpgmqHeaders.From(("header1", "bbb"), ("header2", 987))),
+            await _sut.SendAsync(_testQueueName, new TestMessage { Foo = 3 }, NpgmqHeaders.From("header1", "ccc"))
         };
 
         var messages = await _sut.ReadBatchAsync<TestMessage>(_testQueueName);
@@ -1038,11 +1030,7 @@ public sealed partial class NpgmqClientTest : IClassFixture<PostgresFixture>, IA
         await _sut.CreateQueueAsync(_testQueueName);
 
         // Act
-        var headers = new Dictionary<string, object>
-        {
-            { "some-header", 456 },
-            { "another-header", "test" }
-        };
+        var headers = NpgmqHeaders.From(("some-header", 456), ("another-header", "test"));
         var msgId = await _sut.SendAsync(_testQueueName, new TestMessage
         {
             Foo = 123,
@@ -1105,11 +1093,7 @@ public sealed partial class NpgmqClientTest : IClassFixture<PostgresFixture>, IA
         await _sut.CreateQueueAsync(_testQueueName);
 
         // Act
-        var headers = new Dictionary<string, object>
-        {
-            { "some-header", 456 },
-            { "another-header", "test" }
-        };
+        var headers = NpgmqHeaders.From(("some-header", 456), ("another-header", "test"));
         var msgId = await _sut.SendAsync(_testQueueName, new TestMessage
         {
             Foo = 123,
@@ -1130,11 +1114,7 @@ public sealed partial class NpgmqClientTest : IClassFixture<PostgresFixture>, IA
         await _sut.CreateQueueAsync(_testQueueName);
 
         // Act
-        var headers = new Dictionary<string, object>
-        {
-            { "some-header", 456 },
-            { "another-header", "test" }
-        };
+        var headers = NpgmqHeaders.From(("some-header", 456), ("another-header", "test"));
         var delay = DateTimeOffset.Now.AddSeconds(100);
         var msgId = await _sut.SendAsync(_testQueueName, new TestMessage
         {
@@ -1184,11 +1164,11 @@ public sealed partial class NpgmqClientTest : IClassFixture<PostgresFixture>, IA
             new() { Foo = 2 },
             new() { Foo = 3 }
         };
-        var headers = new List<Dictionary<string, object>>
+        var headers = new[]
         {
-            new() { { "header1", "aaa" } },
-            new() { { "header1", "bbb" }, { "header2", 987 } },
-            new() { { "header1", "ccc" } }
+            NpgmqHeaders.From("header1", "aaa"),
+            NpgmqHeaders.From(("header1", "bbb"), ("header2", 987)),
+            NpgmqHeaders.From("header1", "ccc")
         };
         var msgIds = await _sut.SendBatchAsync(_testQueueName, messages, headers);
 
@@ -1271,11 +1251,11 @@ public sealed partial class NpgmqClientTest : IClassFixture<PostgresFixture>, IA
             new() { Foo = 2 },
             new() { Foo = 3 }
         };
-        var headers = new List<Dictionary<string, object>>
+        var headers = new[]
         {
-            new() { { "header1", "aaa" } },
-            new() { { "header1", "bbb" }, { "header2", 987 } },
-            new() { { "header1", "ccc" } }
+            NpgmqHeaders.From("header1", "aaa"),
+            NpgmqHeaders.From(("header1", "bbb"), ("header2", 987)),
+            NpgmqHeaders.From("header1", "ccc")
         };
         var msgIds = await _sut.SendBatchAsync(_testQueueName, messages, headers, 100);
 
@@ -1298,11 +1278,11 @@ public sealed partial class NpgmqClientTest : IClassFixture<PostgresFixture>, IA
             new() { Foo = 2 },
             new() { Foo = 3 }
         };
-        var headers = new List<Dictionary<string, object>>
+        var headers = new[]
         {
-            new() { { "header1", "aaa" } },
-            new() { { "header1", "bbb" }, { "header2", 987 } },
-            new() { { "header1", "ccc" } }
+            NpgmqHeaders.From("header1", "aaa"),
+            NpgmqHeaders.From(("header1", "bbb"), ("header2", 987)),
+            NpgmqHeaders.From("header1", "ccc")
         };
         var delay = DateTimeOffset.Now.AddSeconds(100);
         var msgIds = await _sut.SendBatchAsync(_testQueueName, messages, headers, delay);

--- a/Npgmq.Test/NpgmqClientTest.cs
+++ b/Npgmq.Test/NpgmqClientTest.cs
@@ -449,19 +449,22 @@ public sealed partial class NpgmqClientTest : IClassFixture<PostgresFixture>, IA
         // Wait a little bit and then send some messages
         await Task.Delay(1000);
         var producer = new NpgmqClient(_postgresFixture.DataSource);
-        await producer.SendAsync(_testQueueName, new TestMessage { Foo = 1 });
-        await producer.SendAsync(_testQueueName, new TestMessage { Foo = 2 });
-        await producer.SendAsync(_testQueueName, new TestMessage { Foo = 3 });
-        await producer.SendAsync(_testQueueName, new TestMessage { Foo = 4 });
-        await producer.SendAsync(_testQueueName, new TestMessage { Foo = 5 });
+        var msgIds = await producer.SendBatchAsync(
+            _testQueueName,
+            [
+                new TestMessage { Foo = 1 },
+                new TestMessage { Foo = 2 },
+                new TestMessage { Foo = 3 },
+                new TestMessage { Foo = 4 },
+                new TestMessage { Foo = 5 }
+            ]
+        );
 
         // Get the messages received by the poll
         var messages = await pollTask;
 
         // Assert
-        Assert.True(messages.Count > 0);
-        Assert.True(messages.Count <= 3);
-        // TODO: Improve this test, keeping in mind that each call to PollBatchAsync is not guaranteed to read the limit
+        messages.Select(m => m.MsgId).ShouldDeepEqual(new[] { msgIds[0], msgIds[1], msgIds[2] });
     }
 
     [Fact]
@@ -476,11 +479,16 @@ public sealed partial class NpgmqClientTest : IClassFixture<PostgresFixture>, IA
         // Wait a little bit and then send some messages
         await Task.Delay(1000);
         var producer = new NpgmqClient(_postgresFixture.DataSource);
-        await producer.SendAsync(_testQueueName, new TestMessage { Foo = 1 });
-        await producer.SendAsync(_testQueueName, new TestMessage { Foo = 2 });
-        await producer.SendAsync(_testQueueName, new TestMessage { Foo = 3 });
-        await producer.SendAsync(_testQueueName, new TestMessage { Foo = 4 });
-        await producer.SendAsync(_testQueueName, new TestMessage { Foo = 5 });
+        var msgIds = await producer.SendBatchAsync(
+            _testQueueName,
+            [
+                new TestMessage { Foo = 1 },
+                new TestMessage { Foo = 2 },
+                new TestMessage { Foo = 3 },
+                new TestMessage { Foo = 4 },
+                new TestMessage { Foo = 5 }
+            ]
+        );
 
         // Get the messages received by the poll
         var batch1 = await pollTask;
@@ -493,7 +501,8 @@ public sealed partial class NpgmqClientTest : IClassFixture<PostgresFixture>, IA
         Assert.True(batch1.Count <= 3);
         Assert.True(batch2.Count > 0);
         Assert.True(batch2.Count <= 3);
-        Assert.Equal(batch1.Count + batch2.Count, batch1.Select(x => x.MsgId).Union(batch2.Select(x => x.MsgId)).Count());
+        var combined = batch1.Select(x => x.MsgId).Union(batch2.Select(x => x.MsgId)).ToList();
+        combined.ShouldDeepEqual(new[] { msgIds[0], msgIds[1], msgIds[2], msgIds[3], msgIds[4] });
     }
 
     [Fact]

--- a/Npgmq.Test/NpgmqHeadersTest.cs
+++ b/Npgmq.Test/NpgmqHeadersTest.cs
@@ -16,6 +16,16 @@ public class NpgmqHeadersTest
     }
 
     [Fact]
+    public void From_should_create_empty_headers_dictionary_from_tuples()
+    {
+        // Act
+        var headers = NpgmqHeaders.From();
+
+        // Assert
+        Assert.Empty(headers);
+    }
+
+    [Fact]
     public void From_should_create_headers_dictionary_from_single_key_value()
     {
         // Act

--- a/Npgmq.Test/NpgmqHeadersTest.cs
+++ b/Npgmq.Test/NpgmqHeadersTest.cs
@@ -1,0 +1,28 @@
+namespace Npgmq.Test;
+
+public class NpgmqHeadersTest
+{
+    [Fact]
+    public void From_should_create_headers_dictionary_from_tuples()
+    {
+        // Act
+        var headers = NpgmqHeaders.From(("key1", "value1"), ("key2", 123), ("key3", true));
+
+        // Assert
+        Assert.Equal(3, headers.Count);
+        Assert.Equal("value1", headers["key1"]);
+        Assert.Equal(123, headers["key2"]);
+        Assert.Equal(true, headers["key3"]);
+    }
+
+    [Fact]
+    public void From_should_create_headers_dictionary_from_single_key_value()
+    {
+        // Act
+        var headers = NpgmqHeaders.From("key", "value");
+
+        // Assert
+        Assert.Single(headers);
+        Assert.Equal("value", headers["key"]);
+    }
+}

--- a/Npgmq/INpgmqClient.Grouped.cs
+++ b/Npgmq/INpgmqClient.Grouped.cs
@@ -1,0 +1,78 @@
+namespace Npgmq;
+
+public partial interface INpgmqClient
+{
+    /// <summary>
+    /// Poll a queue for multiple grouped messages.
+    /// </summary>
+    /// <remarks>
+    /// Requires pgmq 1.9.0 or later.
+    /// </remarks>
+    /// <param name="queueName">The queue name.</param>
+    /// <param name="vt">The visibility time in seconds.</param>
+    /// <param name="limit">The maximum number of messages to read.</param>
+    /// <param name="pollTimeoutSeconds">The amount of time to poll for, in seconds.</param>
+    /// <param name="pollIntervalMilliseconds">The amount of time to wait between polls, in milliseconds.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <typeparam name="T">The message type.</typeparam>
+    /// <returns>The messages read.</returns>
+    Task<List<NpgmqMessage<T>>> PollGroupedAsync<T>(string queueName, int vt = INpgmqClient.DefaultVt, int limit = INpgmqClient.DefaultReadBatchLimit, int pollTimeoutSeconds = INpgmqClient.DefaultPollTimeoutSeconds, int pollIntervalMilliseconds = INpgmqClient.DefaultPollIntervalMilliseconds, CancellationToken cancellationToken = default) where T : class;
+
+    /// <summary>
+    /// Poll a queue for multiple grouped messages using round-robin group selection.
+    /// </summary>
+    /// <remarks>
+    /// Requires pgmq 1.9.0 or later.
+    /// </remarks>
+    /// <param name="queueName">The queue name.</param>
+    /// <param name="vt">The visibility time in seconds.</param>
+    /// <param name="limit">The maximum number of messages to read.</param>
+    /// <param name="pollTimeoutSeconds">The amount of time to poll for, in seconds.</param>
+    /// <param name="pollIntervalMilliseconds">The amount of time to wait between polls, in milliseconds.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <typeparam name="T">The message type.</typeparam>
+    /// <returns>The messages read.</returns>
+    Task<List<NpgmqMessage<T>>> PollGroupedRoundRobinAsync<T>(string queueName, int vt = INpgmqClient.DefaultVt, int limit = INpgmqClient.DefaultReadBatchLimit, int pollTimeoutSeconds = INpgmqClient.DefaultPollTimeoutSeconds, int pollIntervalMilliseconds = INpgmqClient.DefaultPollIntervalMilliseconds, CancellationToken cancellationToken = default) where T : class;
+
+    /// <summary>
+    /// Read multiple grouped messages from queue.
+    /// </summary>
+    /// <remarks>
+    /// Requires pgmq 1.9.0 or later.
+    /// </remarks>
+    /// <param name="queueName">The queue name.</param>
+    /// <param name="vt">The visibility time in seconds.</param>
+    /// <param name="limit">The maximum number of messages to read.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <typeparam name="T">The message type.</typeparam>
+    /// <returns>The messages read.</returns>
+    Task<List<NpgmqMessage<T>>> ReadGroupedAsync<T>(string queueName, int vt = INpgmqClient.DefaultVt, int limit = INpgmqClient.DefaultReadBatchLimit, CancellationToken cancellationToken = default) where T : class;
+
+    /// <summary>
+    /// Read multiple grouped messages from queue using round-robin group selection.
+    /// </summary>
+    /// <remarks>
+    /// Requires pgmq 1.9.0 or later.
+    /// </remarks>
+    /// <param name="queueName">The queue name.</param>
+    /// <param name="vt">The visibility time in seconds.</param>
+    /// <param name="limit">The maximum number of messages to read.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <typeparam name="T">The message type.</typeparam>
+    /// <returns>The messages read.</returns>
+    Task<List<NpgmqMessage<T>>> ReadGroupedRoundRobinAsync<T>(string queueName, int vt = INpgmqClient.DefaultVt, int limit = INpgmqClient.DefaultReadBatchLimit, CancellationToken cancellationToken = default) where T : class;
+
+    /// <summary>
+    /// Read multiple grouped head messages from queue.
+    /// </summary>
+    /// <remarks>
+    /// Requires pgmq 1.11.1 or later.
+    /// </remarks>
+    /// <param name="queueName">The queue name.</param>
+    /// <param name="vt">The visibility time in seconds.</param>
+    /// <param name="limit">The maximum number of messages to read.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <typeparam name="T">The message type.</typeparam>
+    /// <returns>The messages read.</returns>
+    Task<List<NpgmqMessage<T>>> ReadGroupedHeadAsync<T>(string queueName, int vt = INpgmqClient.DefaultVt, int limit = INpgmqClient.DefaultReadBatchLimit, CancellationToken cancellationToken = default) where T : class;
+}

--- a/Npgmq/INpgmqClient.Grouped.cs
+++ b/Npgmq/INpgmqClient.Grouped.cs
@@ -75,4 +75,23 @@ public partial interface INpgmqClient
     /// <typeparam name="T">The message type.</typeparam>
     /// <returns>The messages read.</returns>
     Task<List<NpgmqMessage<T>>> ReadGroupedHeadAsync<T>(string queueName, int vt = INpgmqClient.DefaultVt, int limit = INpgmqClient.DefaultReadBatchLimit, CancellationToken cancellationToken = default) where T : class;
+
+    /// <summary>
+    /// Creates an index on a queue's table header column to optimize grouped message reads.
+    /// </summary>
+    /// <remarks>
+    /// Requires pgmq 1.9.0 or later.
+    /// </remarks>
+    /// <param name="queueName">The queue name.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    Task CreateFifoIndexAsync(string queueName, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Creates indexes on all queue table header columns to optimize grouped message reads.
+    /// </summary>
+    /// <remarks>
+    /// Requires pgmq 1.9.0 or later.
+    /// </remarks>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    Task CreateFifoIndexesAsync(CancellationToken cancellationToken = default);
 }

--- a/Npgmq/NpgmqClient.Grouped.cs
+++ b/Npgmq/NpgmqClient.Grouped.cs
@@ -1,0 +1,124 @@
+namespace Npgmq;
+
+public partial class NpgmqClient
+{
+    public async Task<List<NpgmqMessage<T>>> PollGroupedAsync<T>(string queueName, int vt = INpgmqClient.DefaultVt, int limit = INpgmqClient.DefaultReadBatchLimit, int pollTimeoutSeconds = INpgmqClient.DefaultPollTimeoutSeconds, int pollIntervalMilliseconds = INpgmqClient.DefaultPollIntervalMilliseconds, CancellationToken cancellationToken = default) where T : class
+    {
+        try
+        {
+            var cmd = await _commandFactory.CreateAsync("SELECT msg_id, read_ct, enqueued_at, vt, message, headers FROM pgmq.read_grouped_with_poll(@queue_name, @vt, @qty, @max_poll_seconds, @poll_interval_ms);", cancellationToken).ConfigureAwait(false);
+            await using (cmd.ConfigureAwait(false))
+            {
+                cmd.Parameters.AddWithValue("@queue_name", queueName);
+                cmd.Parameters.AddWithValue("@vt", vt);
+                cmd.Parameters.AddWithValue("@qty", limit);
+                cmd.Parameters.AddWithValue("@max_poll_seconds", pollTimeoutSeconds);
+                cmd.Parameters.AddWithValue("@poll_interval_ms", pollIntervalMilliseconds);
+                var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+                await using (reader.ConfigureAwait(false))
+                {
+                    return await ReadMessagesAsync<T>(reader, cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            throw new NpgmqException($"Failed to poll queue {queueName}.", ex);
+        }
+    }
+
+    public async Task<List<NpgmqMessage<T>>> PollGroupedRoundRobinAsync<T>(string queueName, int vt = INpgmqClient.DefaultVt, int limit = INpgmqClient.DefaultReadBatchLimit, int pollTimeoutSeconds = INpgmqClient.DefaultPollTimeoutSeconds, int pollIntervalMilliseconds = INpgmqClient.DefaultPollIntervalMilliseconds, CancellationToken cancellationToken = default) where T : class
+    {
+        try
+        {
+            var cmd = await _commandFactory.CreateAsync("SELECT msg_id, read_ct, enqueued_at, vt, message, headers FROM pgmq.read_grouped_rr_with_poll(@queue_name, @vt, @qty, @max_poll_seconds, @poll_interval_ms);", cancellationToken).ConfigureAwait(false);
+            await using (cmd.ConfigureAwait(false))
+            {
+                cmd.Parameters.AddWithValue("@queue_name", queueName);
+                cmd.Parameters.AddWithValue("@vt", vt);
+                cmd.Parameters.AddWithValue("@qty", limit);
+                cmd.Parameters.AddWithValue("@max_poll_seconds", pollTimeoutSeconds);
+                cmd.Parameters.AddWithValue("@poll_interval_ms", pollIntervalMilliseconds);
+                var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+                await using (reader.ConfigureAwait(false))
+                {
+                    return await ReadMessagesAsync<T>(reader, cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            throw new NpgmqException($"Failed to poll queue {queueName}.", ex);
+        }
+    }
+
+    public async Task<List<NpgmqMessage<T>>> ReadGroupedAsync<T>(string queueName, int vt = INpgmqClient.DefaultVt, int limit = INpgmqClient.DefaultReadBatchLimit, CancellationToken cancellationToken = default) where T : class
+    {
+        try
+        {
+            var cmd = await _commandFactory.CreateAsync("SELECT msg_id, read_ct, enqueued_at, vt, message, headers FROM pgmq.read_grouped(@queue_name, @vt, @qty);", cancellationToken).ConfigureAwait(false);
+            await using (cmd.ConfigureAwait(false))
+            {
+                cmd.Parameters.AddWithValue("@queue_name", queueName);
+                cmd.Parameters.AddWithValue("@vt", vt);
+                cmd.Parameters.AddWithValue("@qty", limit);
+                var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+                await using (reader.ConfigureAwait(false))
+                {
+                    return await ReadMessagesAsync<T>(reader, cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            throw new NpgmqException($"Failed to read from queue {queueName}.", ex);
+        }
+    }
+
+    public async Task<List<NpgmqMessage<T>>> ReadGroupedRoundRobinAsync<T>(string queueName, int vt = INpgmqClient.DefaultVt, int limit = INpgmqClient.DefaultReadBatchLimit, CancellationToken cancellationToken = default) where T : class
+    {
+        try
+        {
+            var cmd = await _commandFactory.CreateAsync("SELECT msg_id, read_ct, enqueued_at, vt, message, headers FROM pgmq.read_grouped_rr(@queue_name, @vt, @qty);", cancellationToken).ConfigureAwait(false);
+            await using (cmd.ConfigureAwait(false))
+            {
+                cmd.Parameters.AddWithValue("@queue_name", queueName);
+                cmd.Parameters.AddWithValue("@vt", vt);
+                cmd.Parameters.AddWithValue("@qty", limit);
+                var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+                await using (reader.ConfigureAwait(false))
+                {
+                    return await ReadMessagesAsync<T>(reader, cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            throw new NpgmqException($"Failed to read from queue {queueName}.", ex);
+        }
+    }
+
+    public async Task<List<NpgmqMessage<T>>> ReadGroupedHeadAsync<T>(string queueName, int vt = INpgmqClient.DefaultVt, int limit = INpgmqClient.DefaultReadBatchLimit, CancellationToken cancellationToken = default) where T : class
+    {
+        try
+        {
+            var cmd = await _commandFactory.CreateAsync("SELECT msg_id, read_ct, enqueued_at, vt, message, headers FROM pgmq.read_grouped_head(@queue_name, @vt, @qty);", cancellationToken).ConfigureAwait(false);
+            await using (cmd.ConfigureAwait(false))
+            {
+                cmd.Parameters.AddWithValue("@queue_name", queueName);
+                cmd.Parameters.AddWithValue("@vt", vt);
+                cmd.Parameters.AddWithValue("@qty", limit);
+                var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+                await using (reader.ConfigureAwait(false))
+                {
+                    return await ReadMessagesAsync<T>(reader, cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            throw new NpgmqException($"Failed to read from queue {queueName}.", ex);
+        }
+    }
+
+}

--- a/Npgmq/NpgmqClient.Grouped.cs
+++ b/Npgmq/NpgmqClient.Grouped.cs
@@ -121,4 +121,36 @@ public partial class NpgmqClient
         }
     }
 
+    public async Task CreateFifoIndexAsync(string queueName, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var cmd = await _commandFactory.CreateAsync("SELECT pgmq.create_fifo_index(@queue_name);", cancellationToken).ConfigureAwait(false);
+            await using (cmd.ConfigureAwait(false))
+            {
+                cmd.Parameters.AddWithValue("@queue_name", queueName);
+                await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            throw new NpgmqException($"Failed to create FIFO index for queue {queueName}.", ex);
+        }
+    }
+
+    public async Task CreateFifoIndexesAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var cmd = await _commandFactory.CreateAsync("SELECT pgmq.create_fifo_indexes_all();", cancellationToken).ConfigureAwait(false);
+            await using (cmd.ConfigureAwait(false))
+            {
+                await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            throw new NpgmqException("Failed to create all FIFO indexes.", ex);
+        }
+    }
 }

--- a/Npgmq/NpgmqClient.cs
+++ b/Npgmq/NpgmqClient.cs
@@ -284,13 +284,13 @@ public partial class NpgmqClient : INpgmqClient
     {
         try
         {
-            var cmd = await _commandFactory.CreateAsync("SELECT msg_id, read_ct, enqueued_at, vt, message, headers FROM pgmq.read_with_poll(@queue_name, @vt, @qty, @poll_timeout_s, @poll_interval_ms);", cancellationToken).ConfigureAwait(false);
+            var cmd = await _commandFactory.CreateAsync("SELECT msg_id, read_ct, enqueued_at, vt, message, headers FROM pgmq.read_with_poll(@queue_name, @vt, @qty, @max_poll_seconds, @poll_interval_ms);", cancellationToken).ConfigureAwait(false);
             await using (cmd.ConfigureAwait(false))
             {
                 cmd.Parameters.AddWithValue("@queue_name", queueName);
                 cmd.Parameters.AddWithValue("@vt", vt);
                 cmd.Parameters.AddWithValue("@qty", limit);
-                cmd.Parameters.AddWithValue("@poll_timeout_s", pollTimeoutSeconds);
+                cmd.Parameters.AddWithValue("@max_poll_seconds", pollTimeoutSeconds);
                 cmd.Parameters.AddWithValue("@poll_interval_ms", pollIntervalMilliseconds);
                 var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
                 await using (reader.ConfigureAwait(false))

--- a/Npgmq/NpgmqHeaders.cs
+++ b/Npgmq/NpgmqHeaders.cs
@@ -25,6 +25,6 @@ public static class NpgmqHeaders
     /// </summary>
     /// <param name="key">The header key.</param>
     /// <param name="value">The header value.</param>
-    /// <returns>>A dictionary representing the headers.</returns>
+    /// <returns>A dictionary representing the headers.</returns>
     public static Dictionary<string, object> From(string key, object value) => From((key, value));
 }

--- a/Npgmq/NpgmqHeaders.cs
+++ b/Npgmq/NpgmqHeaders.cs
@@ -1,0 +1,18 @@
+namespace Npgmq;
+
+public static class NpgmqHeaders
+{
+    public const string XPgmqGroup = "x-pgmq-group";
+
+    public static Dictionary<string, object> From(params ValueTuple<string, object>[] tuples)
+    {
+        var headers = new Dictionary<string, object>();
+        foreach (var tuple in tuples)
+        {
+            headers[tuple.Item1] = tuple.Item2;
+        }
+        return headers;
+    }
+
+    public static Dictionary<string, object> From(string key, object value) => From((key, value));
+}

--- a/Npgmq/NpgmqHeaders.cs
+++ b/Npgmq/NpgmqHeaders.cs
@@ -1,9 +1,15 @@
 namespace Npgmq;
 
+/// <summary>
+/// Helper class for creating message headers in a more convenient way.
+/// </summary>
 public static class NpgmqHeaders
 {
-    public const string XPgmqGroup = "x-pgmq-group";
-
+    /// <summary>
+    /// Creates a headers dictionary from an array of key-value tuples.
+    /// </summary>
+    /// <param name="tuples">The key-value pairs to include in the headers.</param>
+    /// <returns>A dictionary representing the headers.</returns>
     public static Dictionary<string, object> From(params ValueTuple<string, object>[] tuples)
     {
         var headers = new Dictionary<string, object>();
@@ -14,5 +20,11 @@ public static class NpgmqHeaders
         return headers;
     }
 
+    /// <summary>
+    /// Creates a headers dictionary from a single key-value pair.
+    /// </summary>
+    /// <param name="key">The header key.</param>
+    /// <param name="value">The header value.</param>
+    /// <returns>>A dictionary representing the headers.</returns>
     public static Dictionary<string, object> From(string key, object value) => From((key, value));
 }

--- a/README.md
+++ b/README.md
@@ -142,9 +142,14 @@ When constructed with an existing NpgsqlConnection, concurrent operations are no
 Npgmq is tested with pgmq versions 1.5.1 and higher.
 
 Some features require minimum versions of the pgmq extension:
-* PopAsync(queue, qty): Requires pgmq 1.7.0+
-* SetVtBatchAsync: Requires pgmq 1.8.0+
-* Topic Support: Requires pgmq 1.11.0+
+
+| Feature | Minimum pgmq version |
+| --- | --- |
+| `PopAsync(queue, qty)` | 1.7.0 |
+| `SetVtBatchAsync` | 1.8.0 |
+| FIFO grouped reads | 1.9.0 |
+| Topic support | 1.11.0 |
+| `ReadGroupedHeadAsync` | 1.11.1 |
 
 You can check the installed version:
 ```csharp

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.0",
+    "version": "10.0.202",
     "rollForward": "latestMajor",
     "allowPrerelease": false
   }


### PR DESCRIPTION
This pull request introduces several improvements to the test suite and CI workflow, focusing on expanding test coverage for grouped message features, updating dependencies, and modernizing the build pipeline. The most significant changes include new grouped message tests, enhancements to the GitHub Actions workflow for broader version testing, and refactoring of test code for clarity and maintainability.

### Test Suite Improvements

* Added comprehensive tests for grouped message queue operations, including `PollGroupedAsync`, `PollGroupedRoundRobinAsync`, `ReadGroupedAsync`, `ReadGroupedRoundRobinAsync`, and `ReadGroupedHeadAsync` methods in `NpgmqClientTest.Grouped.cs`, ensuring correct behavior with various grouping and round-robin scenarios.
* Refactored several tests to use `NpgmqHeaders.From` for constructing message headers, improving readability and consistency. [[1]](diffhunk://#diff-369dedd94d406b7ee7f31aa6273f051a288be041a948662b920ff1f47427e2f0L539-R548) [[2]](diffhunk://#diff-369dedd94d406b7ee7f31aa6273f051a288be041a948662b920ff1f47427e2f0L740-R745) [[3]](diffhunk://#diff-369dedd94d406b7ee7f31aa6273f051a288be041a948662b920ff1f47427e2f0L882-R885) [[4]](diffhunk://#diff-369dedd94d406b7ee7f31aa6273f051a288be041a948662b920ff1f47427e2f0L1032-R1033) [[5]](diffhunk://#diff-369dedd94d406b7ee7f31aa6273f051a288be041a948662b920ff1f47427e2f0L1099-R1096) [[6]](diffhunk://#diff-369dedd94d406b7ee7f31aa6273f051a288be041a948662b920ff1f47427e2f0L1124-R1117)
* Updated batch polling tests to use `SendBatchAsync` for more efficient message sending and improved assertions on received message IDs. [[1]](diffhunk://#diff-369dedd94d406b7ee7f31aa6273f051a288be041a948662b920ff1f47427e2f0L452-R467) [[2]](diffhunk://#diff-369dedd94d406b7ee7f31aa6273f051a288be041a948662b920ff1f47427e2f0L479-R491) [[3]](diffhunk://#diff-369dedd94d406b7ee7f31aa6273f051a288be041a948662b920ff1f47427e2f0L496-R505)

### CI/CD Pipeline Enhancements

* Refactored `.github/workflows/build.yml` to:
  - Update GitHub Actions and .NET setup actions to their latest major versions.
  - Replace individual test jobs with a matrix strategy, running tests across a wider range of `pgmq` versions for better compatibility assurance.
  - Split build, test, pack, and publish steps into separate jobs, improving maintainability and clarity.
  - Update artifact upload/download actions to latest versions. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L22-R27) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L47-R115)

### Dependency Updates

* Updated `Microsoft.Extensions.Configuration.EnvironmentVariables`, `Microsoft.Extensions.Configuration.UserSecrets`, and `Microsoft.Extensions.DependencyInjection` package references to version `10.0.6` in test and example projects for improved compatibility and security. [[1]](diffhunk://#diff-b39f1b726a46a7773261c0aab6cee0d62e1873be6eab385ccd0eaed4393f5b75L16-R17) [[2]](diffhunk://#diff-13dfdebc26ef63f96dfa00bbf106ba98af834ed9dbd29a6d5214a5bf32c7096eL17-R19)

### Stress Test Adjustments

* Reduced producer and consumer counts in stress tests to avoid exceeding PostgreSQL's maximum connection limits, improving test reliability. [[1]](diffhunk://#diff-54003866dfddfb0a6d69758769d742c9964282b4b3d85bfa53603e6467a3225cL31-R32) [[2]](diffhunk://#diff-54003866dfddfb0a6d69758769d742c9964282b4b3d85bfa53603e6467a3225cL79-R80)