### PR TITLE
Update build configuration and SDK settings for improved version handling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,14 +1,12 @@
 name: Build
 
 on:
-  create:
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+.*'
   push:
     branches:
-      - '*'
+      - '**'
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+.*'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-*'
   pull_request:
   workflow_dispatch:
 

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "version": "10.0.202",
-    "rollForward": "latestMajor",
+    "rollForward": "latestFeature",
     "allowPrerelease": false
   }
 }


### PR DESCRIPTION
This pull request makes two main updates: it refines the workflow trigger patterns in the GitHub Actions build configuration, and it changes the .NET SDK roll-forward policy in `global.json` for more controlled SDK version selection.

**CI/CD Workflow Improvements:**
- Updated `.github/workflows/build.yml` to:
  - Remove the `create` event trigger for tags.
  - Change the `push` branch pattern from `'*'` to `'**'` to better match branches at any depth.
  - Refine tag patterns to separately match standard version tags (e.g., `v1.2.3`) and pre-release tags (e.g., `v1.2.3-beta`).

**.NET SDK Versioning Policy:**
- Changed the `rollForward` policy in `global.json` from `latestMajor` to `latestFeature`, ensuring the SDK will only roll forward to the latest feature band within the specified major version, rather than to any higher major version.